### PR TITLE
feat: build intern scheduling web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# Advance-scheduler
+# Advance Scheduler
+
+Advance Scheduler is a zero-dependency Node.js web application that collects intern availability, automatically generates a fair floor schedule across nine stations, and exposes a calendar interface for quick manual adjustments.
+
+## Features
+
+- **Availability intake** – interns submit the windows they can work, including optional trainer pairings for onboarding shifts.
+- **Fair auto-scheduling** – balances requested hours against the nine-station capacity on an hour-by-hour basis while keeping training pairs on the same station.
+- **Open-slot surfacing** – highlights empty stations that can be offered to interns when capacity is available.
+- **FullCalendar interface** – drag-and-drop adjustments, duplication and removal of assignments directly from the calendar.
+- **Transparency dashboards** – summarize requested vs. assigned hours to help maintain fairness.
+
+## Getting started
+
+1. **Install Node.js** (18+) locally.
+2. **Install dependencies** – the project is dependency-free so there is nothing to install.
+3. **Run the application**:
+
+   ```bash
+   npm start
+   ```
+
+4. **Open the UI** at [http://localhost:3000](http://localhost:3000).
+
+The API and the static frontend are served from the same Node.js process. All data is persisted inside `server/data/store.json`.
+
+## API overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/interns` | List interns. |
+| POST | `/api/interns` | Create a new intern (`name`, `isTrainer`, `requiresTrainer`). |
+| GET | `/api/availabilities` | List availability submissions. |
+| POST | `/api/availabilities` | Submit availability (`internId`, `day`, `start`, `end`, `sessionType`, optional `trainerId`). |
+| DELETE | `/api/availabilities/:id` | Remove an availability entry. |
+| POST | `/api/schedule/generate` | Generate a new schedule using current availability. |
+| GET | `/api/schedule` | Fetch the latest generated schedule and open slot summary. |
+| PUT | `/api/schedule/assignment/:id` | Manually adjust an assignment (day, start, end, station). |
+| POST | `/api/schedule/assignment` | Create a manual assignment or duplicate an existing one. |
+| DELETE | `/api/schedule/assignment/:id` | Delete an assignment from the schedule. |
+
+## Scheduling logic
+
+- Time is evaluated in one-hour blocks between 07:00 and 22:00.
+- A maximum of nine stations may be active each hour; training pairs share a station while counting both the trainee and the trainer toward fairness metrics.
+- Candidates for each hour are sorted by their assigned/requested hour ratio, ensuring interns with fewer assigned hours are prioritized.
+- Trainers must have overlapping availability to cover a training request; otherwise the session is skipped.
+- The generator records waitlisted interns for any hour that exceeds the station limit and surfaces empty stations as actionable open slots.
+
+## Data persistence
+
+All data lives in `server/data/store.json`. Back up this file before redeploying if you want to preserve historical submissions.
+
+## Development notes
+
+- The UI uses the CDN build of [FullCalendar](https://fullcalendar.io/) and modern CSS for styling.
+- The server relies solely on Node.js core modules to simplify deployment in restricted environments.
+- Feel free to extend the generator with additional fairness rules (e.g., prioritizing trainees, minimum weekly hours) as business requirements evolve.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,375 @@
+const API_BASE = '';
+
+const calendarElement = document.getElementById('calendar');
+const availabilityTableBody = document.getElementById('availabilityTableBody');
+const internForm = document.getElementById('internForm');
+const availabilityForm = document.getElementById('availabilityForm');
+const internSelect = document.getElementById('availabilityIntern');
+const trainerSelect = document.getElementById('trainerSelect');
+const trainerField = document.getElementById('trainerField');
+const availabilityTypeSelect = document.getElementById('availabilityType');
+const availabilityRowTemplate = document.getElementById('availabilityRowTemplate');
+const generateButton = document.getElementById('generateSchedule');
+const openSlotsList = document.getElementById('openSlots');
+const summaryTableBody = document.getElementById('summaryTableBody');
+const lastGeneratedLabel = document.getElementById('lastGenerated');
+const duplicateButton = document.getElementById('duplicateAssignment');
+const deleteButton = document.getElementById('deleteAssignment');
+
+let interns = [];
+let availabilities = [];
+let schedule = { assignments: [], openSlots: [], totalsByIntern: [] };
+let calendar;
+let selectedEventId = null;
+
+function dayToDate(dayName) {
+  const now = new Date();
+  const currentDay = now.getDay();
+  const desiredDay = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].indexOf(dayName);
+  if (desiredDay === -1) return now;
+  const distance = (desiredDay + 7 - currentDay) % 7;
+  const target = new Date(now);
+  target.setDate(now.getDate() + distance);
+  target.setHours(0, 0, 0, 0);
+  return target;
+}
+
+function toCalendarEvent(assignment) {
+  const intern = interns.find((item) => item.id === assignment.internId);
+  const trainer = assignment.trainerId ? interns.find((item) => item.id === assignment.trainerId) : null;
+  const startDate = dayToDate(assignment.day);
+  const [startHour, startMinute] = assignment.start.split(':').map(Number);
+  const [endHour, endMinute] = assignment.end.split(':').map(Number);
+  const start = new Date(startDate);
+  start.setHours(startHour, startMinute, 0, 0);
+  const end = new Date(startDate);
+  end.setHours(endHour, endMinute, 0, 0);
+
+  const titleParts = [];
+  if (intern) titleParts.push(intern.name);
+  if (trainer) titleParts.push(`+ ${trainer.name}`);
+  const title = titleParts.join(' ');
+
+  return {
+    id: assignment.id,
+    title: title || 'Unassigned',
+    start,
+    end,
+    extendedProps: {
+      station: assignment.station,
+      type: assignment.type,
+      internId: assignment.internId,
+      trainerId: assignment.trainerId || null,
+      day: assignment.day
+    },
+    classNames: [assignment.type === 'training' ? 'training-event' : 'independent-event']
+  };
+}
+
+function renderCalendar() {
+  if (calendar) {
+    calendar.destroy();
+  }
+  calendar = new FullCalendar.Calendar(calendarElement, {
+    initialView: 'timeGridWeek',
+    nowIndicator: true,
+    slotMinTime: '06:00:00',
+    slotMaxTime: '22:00:00',
+    allDaySlot: false,
+    editable: true,
+    droppable: false,
+    eventDurationEditable: false,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'timeGridWeek,timeGridDay'
+    },
+    events: schedule.assignments.map(toCalendarEvent),
+    eventClick(info) {
+      selectedEventId = info.event.id;
+      duplicateButton.disabled = false;
+      deleteButton.disabled = false;
+    },
+    eventDrop(info) {
+      const event = info.event;
+      persistEventUpdate(event).catch((error) => {
+        alert(error.message || 'Unable to update assignment.');
+        info.revert();
+      });
+    }
+  });
+  calendar.render();
+}
+
+async function persistEventUpdate(event) {
+  const body = buildPayloadFromEvent(event);
+  const response = await fetch(`${API_BASE}/api/schedule/assignment/${event.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.error || 'Failed to update assignment');
+  }
+  await refreshSchedule();
+}
+
+function buildPayloadFromEvent(event) {
+  const start = event.start;
+  const end = event.end;
+  const day = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][start.getDay()];
+  const toTimeString = (date) => `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+  return {
+    day,
+    start: toTimeString(start),
+    end: toTimeString(end)
+  };
+}
+
+async function loadInterns() {
+  const response = await fetch(`${API_BASE}/api/interns`);
+  interns = await response.json();
+  renderInternOptions();
+}
+
+function renderInternOptions() {
+  internSelect.innerHTML = '';
+  trainerSelect.innerHTML = '<option value="">Select trainer</option>';
+  interns.forEach((intern) => {
+    const option = document.createElement('option');
+    option.value = intern.id;
+    option.textContent = intern.name;
+    internSelect.appendChild(option);
+    if (intern.isTrainer) {
+      const trainerOption = document.createElement('option');
+      trainerOption.value = intern.id;
+      trainerOption.textContent = intern.name;
+      trainerSelect.appendChild(trainerOption);
+    }
+  });
+}
+
+async function loadAvailabilities() {
+  const response = await fetch(`${API_BASE}/api/availabilities`);
+  availabilities = await response.json();
+  renderAvailabilityTable();
+}
+
+function renderAvailabilityTable() {
+  availabilityTableBody.innerHTML = '';
+  availabilities
+    .sort((a, b) => {
+      const internA = interns.find((item) => item.id === a.internId)?.name || '';
+      const internB = interns.find((item) => item.id === b.internId)?.name || '';
+      if (internA !== internB) return internA.localeCompare(internB);
+      if (a.day !== b.day) return a.day.localeCompare(b.day);
+      return a.start.localeCompare(b.start);
+    })
+    .forEach((availability) => {
+      const clone = availabilityRowTemplate.content.cloneNode(true);
+      clone.querySelector('.availability-name').textContent = interns.find((intern) => intern.id === availability.internId)?.name || '';
+      clone.querySelector('.availability-day').textContent = availability.day;
+      clone.querySelector('.availability-time').textContent = `${availability.start} – ${availability.end}`;
+      clone.querySelector('.availability-type').textContent = availability.sessionType === 'training' ? 'Training' : 'Independent';
+      const deleteButton = clone.querySelector('button');
+      deleteButton.addEventListener('click', () => deleteAvailability(availability.id));
+      availabilityTableBody.appendChild(clone);
+    });
+}
+
+async function deleteAvailability(id) {
+  const confirmed = confirm('Remove this availability entry?');
+  if (!confirmed) return;
+  await fetch(`${API_BASE}/api/availabilities/${id}`, { method: 'DELETE' });
+  await loadAvailabilities();
+}
+
+async function refreshSchedule() {
+  const response = await fetch(`${API_BASE}/api/schedule`);
+  schedule = await response.json();
+  updateLastGenerated();
+  renderCalendar();
+  renderOpenSlots();
+  renderSummary();
+}
+
+function renderOpenSlots() {
+  openSlotsList.innerHTML = '';
+  if (!schedule.openSlots || schedule.openSlots.length === 0) {
+    const empty = document.createElement('li');
+    empty.textContent = 'All stations filled in scheduled hours.';
+    openSlotsList.appendChild(empty);
+    return;
+  }
+  schedule.openSlots.forEach((slot) => {
+    const item = document.createElement('li');
+    const label = `${slot.day} · ${slot.start} – ${slot.end}`;
+    item.innerHTML = `<span>${label}</span><span>${slot.availableStations} open</span>`;
+    openSlotsList.appendChild(item);
+  });
+}
+
+function renderSummary() {
+  summaryTableBody.innerHTML = '';
+  if (!schedule.totalsByIntern) return;
+  schedule.totalsByIntern
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach((row) => {
+      const tr = document.createElement('tr');
+      const requestedCell = document.createElement('td');
+      requestedCell.textContent = row.requestedHours;
+      const assignedCell = document.createElement('td');
+      assignedCell.textContent = row.assignedHours;
+      tr.innerHTML = `<td>${row.name}</td>`;
+      tr.appendChild(requestedCell);
+      tr.appendChild(assignedCell);
+      summaryTableBody.appendChild(tr);
+    });
+}
+
+function updateLastGenerated() {
+  if (!schedule.generatedAt) {
+    lastGeneratedLabel.textContent = 'No schedule generated yet.';
+    return;
+  }
+  const formatted = new Date(schedule.generatedAt).toLocaleString();
+  lastGeneratedLabel.textContent = `Generated on ${formatted}`;
+}
+
+async function generateSchedule() {
+  generateButton.disabled = true;
+  generateButton.textContent = 'Generating…';
+  try {
+    const response = await fetch(`${API_BASE}/api/schedule/generate`, { method: 'POST' });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(error.error || 'Failed to generate schedule');
+    }
+    schedule = await response.json();
+    updateLastGenerated();
+    renderCalendar();
+    renderOpenSlots();
+    renderSummary();
+  } catch (error) {
+    alert(error.message);
+  } finally {
+    generateButton.disabled = false;
+    generateButton.textContent = 'Generate fresh schedule';
+  }
+}
+
+async function createIntern(event) {
+  event.preventDefault();
+  const name = document.getElementById('internName').value.trim();
+  if (!name) return;
+  const payload = {
+    name,
+    isTrainer: document.getElementById('internTrainer').checked,
+    requiresTrainer: document.getElementById('internRequiresTrainer').checked
+  };
+  const response = await fetch(`${API_BASE}/api/interns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    alert('Unable to add intern');
+    return;
+  }
+  document.getElementById('internName').value = '';
+  document.getElementById('internTrainer').checked = false;
+  document.getElementById('internRequiresTrainer').checked = false;
+  await loadInterns();
+}
+
+async function submitAvailability(event) {
+  event.preventDefault();
+  const payload = {
+    internId: internSelect.value,
+    day: document.getElementById('availabilityDay').value,
+    start: document.getElementById('availabilityStart').value,
+    end: document.getElementById('availabilityEnd').value,
+    sessionType: availabilityTypeSelect.value,
+    trainerId: availabilityTypeSelect.value === 'training' ? trainerSelect.value : null,
+    notes: document.getElementById('availabilityNotes').value.trim()
+  };
+  const response = await fetch(`${API_BASE}/api/availabilities`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unable to submit availability' }));
+    alert(error.error || 'Unable to submit availability');
+    return;
+  }
+  availabilityForm.reset();
+  trainerField.hidden = true;
+  await loadAvailabilities();
+}
+
+function handleSessionTypeChange() {
+  const type = availabilityTypeSelect.value;
+  if (type === 'training') {
+    trainerField.hidden = false;
+  } else {
+    trainerField.hidden = true;
+  }
+}
+
+async function duplicateSelectedAssignment() {
+  if (!selectedEventId) return;
+  const event = calendar.getEventById(selectedEventId);
+  if (!event) return;
+  const payload = buildPayloadFromEvent(event);
+  payload.internId = event.extendedProps.internId;
+  payload.trainerId = event.extendedProps.trainerId;
+  payload.station = event.extendedProps.station;
+  const response = await fetch(`${API_BASE}/api/schedule/assignment`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unable to duplicate assignment' }));
+    alert(error.error || 'Unable to duplicate assignment');
+    return;
+  }
+  await refreshSchedule();
+}
+
+async function deleteSelectedAssignment() {
+  if (!selectedEventId) return;
+  const confirmed = confirm('Delete this assignment from the schedule?');
+  if (!confirmed) return;
+  const response = await fetch(`${API_BASE}/api/schedule/assignment/${selectedEventId}`, {
+    method: 'DELETE'
+  });
+  if (!response.ok) {
+    alert('Unable to delete assignment');
+    return;
+  }
+  selectedEventId = null;
+  duplicateButton.disabled = true;
+  deleteButton.disabled = true;
+  await refreshSchedule();
+}
+
+function attachEventHandlers() {
+  internForm.addEventListener('submit', createIntern);
+  availabilityForm.addEventListener('submit', submitAvailability);
+  availabilityTypeSelect.addEventListener('change', handleSessionTypeChange);
+  generateButton.addEventListener('click', generateSchedule);
+  duplicateButton.addEventListener('click', duplicateSelectedAssignment);
+  deleteButton.addEventListener('click', deleteSelectedAssignment);
+}
+
+async function bootstrap() {
+  attachEventHandlers();
+  await loadInterns();
+  await loadAvailabilities();
+  await refreshSchedule();
+}
+
+bootstrap();

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Advance Scheduler</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Advance Scheduler</h1>
+        <p class="tagline">Balance availability requests with real-time station capacity.</p>
+      </div>
+      <div class="header-actions">
+        <button id="generateSchedule" class="primary">Generate fresh schedule</button>
+        <span id="lastGenerated" class="timestamp"></span>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel" id="availabilityPanel">
+        <h2>1. Manage interns</h2>
+        <form id="internForm" class="form">
+          <div class="form-field">
+            <label for="internName">Intern name</label>
+            <input type="text" id="internName" name="internName" placeholder="e.g. A. Forbes" required />
+          </div>
+          <div class="form-row">
+            <label class="checkbox">
+              <input type="checkbox" id="internTrainer" />
+              <span>Trainer</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="internRequiresTrainer" />
+              <span>Requires trainer</span>
+            </label>
+          </div>
+          <button type="submit" class="secondary">Add intern</button>
+        </form>
+
+        <h2>2. Collect availability</h2>
+        <form id="availabilityForm" class="form">
+          <div class="form-field">
+            <label for="availabilityIntern">Intern</label>
+            <select id="availabilityIntern" required></select>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label for="availabilityDay">Day</label>
+              <select id="availabilityDay" required>
+                <option value="Monday">Monday</option>
+                <option value="Tuesday">Tuesday</option>
+                <option value="Wednesday">Wednesday</option>
+                <option value="Thursday">Thursday</option>
+                <option value="Friday">Friday</option>
+                <option value="Saturday">Saturday</option>
+                <option value="Sunday">Sunday</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="availabilityStart">Start</label>
+              <input type="time" id="availabilityStart" min="06:00" max="22:00" required />
+            </div>
+            <div class="form-field">
+              <label for="availabilityEnd">End</label>
+              <input type="time" id="availabilityEnd" min="07:00" max="23:00" required />
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="availabilityType">Session type</label>
+            <select id="availabilityType">
+              <option value="independent">Independent</option>
+              <option value="training">Training (requires trainer)</option>
+            </select>
+          </div>
+          <div class="form-field" id="trainerField" hidden>
+            <label for="trainerSelect">Trainer</label>
+            <select id="trainerSelect"></select>
+          </div>
+          <div class="form-field">
+            <label for="availabilityNotes">Notes</label>
+            <textarea id="availabilityNotes" rows="2" placeholder="Optional context or requests"></textarea>
+          </div>
+          <button type="submit" class="primary">Submit availability</button>
+        </form>
+
+        <div class="availability-table">
+          <h3>Submitted availability</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Intern</th>
+                <th>Day</th>
+                <th>Time</th>
+                <th>Type</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="availabilityTableBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" id="schedulePanel">
+        <div class="panel-header">
+          <h2>3. Curate the floor schedule</h2>
+          <div class="legend">
+            <span class="badge independent">Independent</span>
+            <span class="badge training">Training pair</span>
+          </div>
+        </div>
+        <div id="calendar"></div>
+
+        <div class="panel-footer">
+          <div>
+            <h3>Open station slots</h3>
+            <ul id="openSlots"></ul>
+          </div>
+          <div>
+            <h3>Fairness overview</h3>
+            <table class="summary-table">
+              <thead>
+                <tr>
+                  <th>Intern</th>
+                  <th>Requested</th>
+                  <th>Assigned</th>
+                </tr>
+              </thead>
+              <tbody id="summaryTableBody"></tbody>
+            </table>
+          </div>
+          <div>
+            <h3>Event controls</h3>
+            <div class="actions">
+              <button id="duplicateAssignment" class="secondary" disabled>Duplicate selected</button>
+              <button id="deleteAssignment" class="danger" disabled>Delete selected</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <template id="availabilityRowTemplate">
+      <tr>
+        <td class="availability-name"></td>
+        <td class="availability-day"></td>
+        <td class="availability-time"></td>
+        <td class="availability-type"></td>
+        <td><button class="danger small">Remove</button></td>
+      </tr>
+    </template>
+
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,336 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f6f8fb;
+  --panel: #ffffff;
+  --border: #d9e1ec;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --secondary: #0f172a;
+  --danger: #dc2626;
+  --text: #0f172a;
+  --muted: #64748b;
+  --success: #047857;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #eff6ff 0%, #f9fafb 60%, #f1f5f9 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+.app-header {
+  padding: 1.75rem 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.tagline {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-top: 0.4rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.timestamp {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 2rem 3rem 3rem;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.legend {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.badge.independent {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary);
+}
+
+.badge.training {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--danger);
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+}
+
+button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--secondary);
+}
+
+button.secondary:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+button.danger {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--danger);
+}
+
+button.danger:hover {
+  background: rgba(220, 38, 38, 0.2);
+}
+
+button.small {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+input,
+ select,
+ textarea {
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  background: #f8fafc;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.availability-table {
+  max-height: 240px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.availability-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.availability-table th,
+.availability-table td {
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.9rem;
+}
+
+.availability-table tbody tr:nth-child(odd) {
+  background: rgba(241, 245, 249, 0.5);
+}
+
+#calendar {
+  background: #fff;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.fc-toolbar.fc-header-toolbar {
+  padding: 0.75rem 1rem;
+}
+
+.fc-toolbar-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.fc .fc-timegrid-slot-label {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.fc .training-event {
+  background: rgba(220, 38, 38, 0.12);
+  border: 1px solid rgba(220, 38, 38, 0.45);
+  color: var(--danger);
+}
+
+.fc .independent-event {
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  color: var(--primary);
+}
+
+.fc-event {
+  border-radius: 12px;
+  padding: 0.35rem;
+}
+
+.fc-event-main {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.fc .fc-daygrid-event {
+  border-radius: 8px;
+  padding: 0.3rem 0.5rem;
+}
+
+#openSlots {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+#openSlots li {
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  color: var(--primary);
+  display: flex;
+  justify-content: space-between;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.summary-table th,
+.summary-table td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.summary-table tbody tr:nth-child(even) {
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+  .panel {
+    padding: 1.25rem;
+  }
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "advance-scheduler",
+  "version": "1.0.0",
+  "description": "Web scheduler to balance intern availability with station capacity",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "lint": "node --check server/index.js"
+  },
+  "keywords": ["scheduler", "interns", "calendar"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/server/data/store.json
+++ b/server/data/store.json
@@ -1,0 +1,1120 @@
+{
+  "interns": [
+    {
+      "id": "af",
+      "name": "A. Forbes",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "sb",
+      "name": "S. Babolal",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "mp",
+      "name": "M. Powell",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "ns",
+      "name": "N. Smith",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "ss",
+      "name": "So. Salmon",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "tb",
+      "name": "T. Burnett",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "kb",
+      "name": "K. Bembridge",
+      "isTrainer": false,
+      "requiresTrainer": true
+    },
+    {
+      "id": "cc",
+      "name": "C. Clarke",
+      "isTrainer": true,
+      "requiresTrainer": false
+    }
+  ],
+  "availabilities": [
+    {
+      "id": "av1",
+      "internId": "af",
+      "day": "Monday",
+      "start": "08:00",
+      "end": "17:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av2",
+      "internId": "sb",
+      "day": "Monday",
+      "start": "07:00",
+      "end": "11:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av3",
+      "internId": "mp",
+      "day": "Monday",
+      "start": "08:00",
+      "end": "13:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av4",
+      "internId": "ns",
+      "day": "Monday",
+      "start": "10:00",
+      "end": "19:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av5",
+      "internId": "ss",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "18:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av6",
+      "internId": "tb",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "18:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av7",
+      "internId": "kb",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "tb"
+    },
+    {
+      "id": "av8",
+      "internId": "cc",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av9",
+      "internId": "af",
+      "day": "Tuesday",
+      "start": "08:00",
+      "end": "13:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av10",
+      "internId": "kb",
+      "day": "Tuesday",
+      "start": "10:00",
+      "end": "16:00",
+      "sessionType": "training",
+      "trainerId": "af"
+    },
+    {
+      "id": "av11",
+      "internId": "ns",
+      "day": "Tuesday",
+      "start": "10:00",
+      "end": "19:00",
+      "sessionType": "independent"
+    },
+    {
+      "id": "av12",
+      "internId": "ss",
+      "day": "Tuesday",
+      "start": "07:00",
+      "end": "13:00",
+      "sessionType": "independent"
+    }
+  ],
+  "schedule": {
+    "assignments": [
+      {
+        "id": "assign-g5kzm2f",
+        "day": "Monday",
+        "hour": 7,
+        "start": "07:00",
+        "end": "08:00",
+        "station": 1,
+        "internId": "sb",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-p2bdpsu",
+        "day": "Monday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "station": 1,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-5gctzzh",
+        "day": "Monday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "station": 2,
+        "internId": "mp",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-7nxkv5x",
+        "day": "Monday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "station": 3,
+        "internId": "sb",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ukoi1wz",
+        "day": "Monday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "station": 1,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ebicn5n",
+        "day": "Monday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "station": 2,
+        "internId": "mp",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-nzionba",
+        "day": "Monday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "station": 3,
+        "internId": "sb",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-bqylkrg",
+        "day": "Monday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-cyt7oi3",
+        "day": "Monday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 2,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ne635l5",
+        "day": "Monday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 3,
+        "internId": "mp",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-1utua1k",
+        "day": "Monday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 4,
+        "internId": "sb",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-6nt08fg",
+        "day": "Monday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-col8ay9",
+        "day": "Monday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 2,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-vpqo8bz",
+        "day": "Monday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 3,
+        "internId": "mp",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-9yobvui",
+        "day": "Monday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ro8h3q0",
+        "day": "Monday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 2,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-nyiiska",
+        "day": "Monday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 3,
+        "internId": "mp",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-en9mq6e",
+        "day": "Monday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "station": 1,
+        "internId": "cc",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-rsii336",
+        "day": "Monday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "station": 2,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-tr5ffhb",
+        "day": "Monday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "station": 3,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-eemq6ou",
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "tb",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-11lb36u",
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 2,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-r2fkhca",
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 3,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-fyf96zf",
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 4,
+        "internId": "cc",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-a6l5uhb",
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 5,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-os8oirn",
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "tb",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-g8eijpi",
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 2,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-6c2w6eb",
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 3,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-8t6o448",
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 4,
+        "internId": "cc",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-fp1e8ad",
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 5,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-dgr7e56",
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "tb",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-r939vkw",
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 2,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-2bp11u6",
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 3,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-99gbbwx",
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 4,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ulng0s8",
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 5,
+        "internId": "cc",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-2jmm1ke",
+        "day": "Monday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "station": 1,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-259jw7i",
+        "day": "Monday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "station": 2,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-le8ody6",
+        "day": "Monday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "station": 3,
+        "internId": "tb",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-zbd1gy9",
+        "day": "Monday",
+        "hour": 18,
+        "start": "18:00",
+        "end": "19:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-4jrgmnp",
+        "day": "Tuesday",
+        "hour": 7,
+        "start": "07:00",
+        "end": "08:00",
+        "station": 1,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ily0cnn",
+        "day": "Tuesday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "station": 1,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-oaywrwf",
+        "day": "Tuesday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "station": 2,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-be874wv",
+        "day": "Tuesday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "station": 1,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-agnfpdp",
+        "day": "Tuesday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "station": 2,
+        "internId": "af",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-oag65fh",
+        "day": "Tuesday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "af",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-1rl2q73",
+        "day": "Tuesday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 2,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ae8smjl",
+        "day": "Tuesday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "station": 3,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-j5eioia",
+        "day": "Tuesday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "af",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-1cfmjxx",
+        "day": "Tuesday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 2,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-ekzz6pb",
+        "day": "Tuesday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "station": 3,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-w21k0b2",
+        "day": "Tuesday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 1,
+        "internId": "kb",
+        "trainerId": "af",
+        "type": "training",
+        "source": "auto"
+      },
+      {
+        "id": "assign-1ypage9",
+        "day": "Tuesday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 2,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-k6vvzhn",
+        "day": "Tuesday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "station": 3,
+        "internId": "ss",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-tb2kahz",
+        "day": "Tuesday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-5py7jbe",
+        "day": "Tuesday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-jwqx6k9",
+        "day": "Tuesday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-lsqdwxw",
+        "day": "Tuesday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-akz7cxy",
+        "day": "Tuesday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      },
+      {
+        "id": "assign-yiojoxe",
+        "day": "Tuesday",
+        "hour": 18,
+        "start": "18:00",
+        "end": "19:00",
+        "station": 1,
+        "internId": "ns",
+        "trainerId": null,
+        "type": "independent",
+        "source": "auto"
+      }
+    ],
+    "openSlots": [
+      {
+        "day": "Monday",
+        "hour": 7,
+        "start": "07:00",
+        "end": "08:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Monday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "availableStations": 5
+      },
+      {
+        "day": "Monday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "availableStations": 4
+      },
+      {
+        "day": "Monday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "availableStations": 4
+      },
+      {
+        "day": "Monday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "availableStations": 4
+      },
+      {
+        "day": "Monday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Monday",
+        "hour": 18,
+        "start": "18:00",
+        "end": "19:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 7,
+        "start": "07:00",
+        "end": "08:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 8,
+        "start": "08:00",
+        "end": "09:00",
+        "availableStations": 7
+      },
+      {
+        "day": "Tuesday",
+        "hour": 9,
+        "start": "09:00",
+        "end": "10:00",
+        "availableStations": 7
+      },
+      {
+        "day": "Tuesday",
+        "hour": 10,
+        "start": "10:00",
+        "end": "11:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Tuesday",
+        "hour": 11,
+        "start": "11:00",
+        "end": "12:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Tuesday",
+        "hour": 12,
+        "start": "12:00",
+        "end": "13:00",
+        "availableStations": 6
+      },
+      {
+        "day": "Tuesday",
+        "hour": 13,
+        "start": "13:00",
+        "end": "14:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 14,
+        "start": "14:00",
+        "end": "15:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 15,
+        "start": "15:00",
+        "end": "16:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 16,
+        "start": "16:00",
+        "end": "17:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 17,
+        "start": "17:00",
+        "end": "18:00",
+        "availableStations": 8
+      },
+      {
+        "day": "Tuesday",
+        "hour": 18,
+        "start": "18:00",
+        "end": "19:00",
+        "availableStations": 8
+      }
+    ],
+    "totalsByIntern": [
+      {
+        "internId": "af",
+        "name": "A. Forbes",
+        "requestedHours": 14,
+        "assignedHours": 14
+      },
+      {
+        "internId": "sb",
+        "name": "S. Babolal",
+        "requestedHours": 4,
+        "assignedHours": 4
+      },
+      {
+        "internId": "mp",
+        "name": "M. Powell",
+        "requestedHours": 5,
+        "assignedHours": 5
+      },
+      {
+        "internId": "ns",
+        "name": "N. Smith",
+        "requestedHours": 18,
+        "assignedHours": 18
+      },
+      {
+        "internId": "ss",
+        "name": "So. Salmon",
+        "requestedHours": 10,
+        "assignedHours": 10
+      },
+      {
+        "internId": "tb",
+        "name": "T. Burnett",
+        "requestedHours": 4,
+        "assignedHours": 4
+      },
+      {
+        "internId": "kb",
+        "name": "K. Bembridge",
+        "requestedHours": 10,
+        "assignedHours": 6
+      },
+      {
+        "internId": "cc",
+        "name": "C. Clarke",
+        "requestedHours": 4,
+        "assignedHours": 4
+      }
+    ],
+    "waitlistedBySlot": {
+      "Monday-14": [
+        "tb"
+      ],
+      "Monday-15": [
+        "tb"
+      ],
+      "Monday-16": [
+        "tb"
+      ],
+      "Tuesday-10": [
+        "af"
+      ],
+      "Tuesday-11": [
+        "af"
+      ],
+      "Tuesday-12": [
+        "af"
+      ]
+    },
+    "daySummaries": {
+      "Monday": {
+        "assignments": 39,
+        "trainings": 3
+      },
+      "Tuesday": {
+        "assignments": 20,
+        "trainings": 3
+      }
+    },
+    "generatedAt": "2025-09-26T21:50:10.061Z"
+  },
+  "settings": {
+    "maxStations": 9,
+    "dayStart": "07:00",
+    "dayEnd": "22:00"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,573 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_PATH = path.join(__dirname, 'data', 'store.json');
+const CLIENT_DIR = path.join(__dirname, '..', 'client');
+const PORT = process.env.PORT || 3000;
+
+const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+function ensureStore() {
+  if (!fs.existsSync(DATA_PATH)) {
+    fs.writeFileSync(DATA_PATH, JSON.stringify({
+      interns: [],
+      availabilities: [],
+      schedule: { assignments: [], generatedAt: null, openSlots: [] },
+      settings: { maxStations: 9, dayStart: '07:00', dayEnd: '22:00' }
+    }, null, 2));
+  }
+}
+
+function readStore() {
+  ensureStore();
+  const raw = fs.readFileSync(DATA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeStore(data) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!body) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function sendJSON(res, statusCode, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(payload);
+}
+
+function sendText(res, statusCode, text) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'text/plain',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(text);
+}
+
+function getMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html';
+    case '.css':
+      return 'text/css';
+    case '.js':
+      return 'application/javascript';
+    case '.json':
+      return 'application/json';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function timeToNumber(timeStr) {
+  const [hour, minute] = timeStr.split(':').map(Number);
+  return hour + minute / 60;
+}
+
+function formatHourLabel(hour) {
+  const end = hour + 1;
+  const toLabel = (value) => {
+    const period = value >= 12 ? 'P.M.' : 'A.M.';
+    const normalized = value % 12 === 0 ? 12 : value % 12;
+    return `${normalized}:00 ${period}`;
+  };
+  return `${toLabel(hour)} – ${toLabel(end)}`;
+}
+
+function pad(num) {
+  return num.toString().padStart(2, '0');
+}
+
+function numberToTime(num) {
+  const hour = Math.floor(num);
+  const minute = Math.round((num - hour) * 60);
+  return `${pad(hour)}:${pad(minute)}`;
+}
+
+function getHourSlots(day, start, end) {
+  const slots = [];
+  let cursor = timeToNumber(start);
+  const endNum = timeToNumber(end);
+  while (cursor < endNum) {
+    slots.push({ day, hour: cursor });
+    cursor += 1;
+  }
+  return slots;
+}
+
+function generateId(prefix = 'id') {
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function buildSchedule(data) {
+  const { interns, availabilities, settings } = data;
+  const maxStations = settings?.maxStations || 9;
+  const internMap = Object.fromEntries(interns.map((intern) => [intern.id, intern]));
+
+  const assignedHours = {};
+  const requestedHours = {};
+  interns.forEach((intern) => {
+    assignedHours[intern.id] = 0;
+    requestedHours[intern.id] = 0;
+  });
+
+  const slotCandidates = new Map();
+  availabilities.forEach((availability) => {
+    const { internId, day, start, end } = availability;
+    const intern = internMap[internId];
+    if (!intern) return;
+    const slots = getHourSlots(day, start, end);
+    requestedHours[internId] = (requestedHours[internId] || 0) + slots.length;
+    slots.forEach(({ day: slotDay, hour }) => {
+      const key = `${slotDay}-${hour}`;
+      if (!slotCandidates.has(key)) {
+        slotCandidates.set(key, []);
+      }
+      slotCandidates.get(key).push({
+        availability,
+        intern,
+        hour
+      });
+    });
+  });
+
+  const assignments = [];
+  const openSlots = [];
+  const waitlistedBySlot = {};
+
+  const scheduledParticipants = new Map();
+
+  function sortCandidates(candidates) {
+    return candidates.sort((a, b) => {
+      const aAssigned = assignedHours[a.intern.id] || 0;
+      const bAssigned = assignedHours[b.intern.id] || 0;
+      const aRequested = requestedHours[a.intern.id] || 1;
+      const bRequested = requestedHours[b.intern.id] || 1;
+      const aRatio = aAssigned / aRequested;
+      const bRatio = bAssigned / bRequested;
+      if (aRatio !== bRatio) {
+        return aRatio - bRatio;
+      }
+      if (aAssigned !== bAssigned) {
+        return aAssigned - bAssigned;
+      }
+      return a.intern.name.localeCompare(b.intern.name);
+    });
+  }
+
+  function canPlaceParticipant(participantId, key) {
+    if (!participantId) return true;
+    const scheduled = scheduledParticipants.get(key);
+    if (!scheduled) return true;
+    return !scheduled.has(participantId);
+  }
+
+  function markParticipants(participants, key) {
+    if (!scheduledParticipants.has(key)) {
+      scheduledParticipants.set(key, new Set());
+    }
+    const store = scheduledParticipants.get(key);
+    participants.forEach((id) => id && store.add(id));
+  }
+
+  const orderedKeys = Array.from(slotCandidates.keys()).sort((a, b) => {
+    const [dayA, hourA] = a.split('-');
+    const [dayB, hourB] = b.split('-');
+    const dayComparison = DAY_ORDER.indexOf(dayA) - DAY_ORDER.indexOf(dayB);
+    if (dayComparison !== 0) return dayComparison;
+    return Number(hourA) - Number(hourB);
+  });
+
+  orderedKeys.forEach((key) => {
+    const [day, hour] = key.split('-');
+    const numericHour = Number(hour);
+    const candidates = slotCandidates.get(key) || [];
+    const trainingCandidates = candidates.filter((item) => item.availability.sessionType === 'training');
+    const independentCandidates = candidates.filter((item) => item.availability.sessionType !== 'training');
+
+    const slotAssignments = [];
+
+    // Process training sessions first to guarantee trainer pairing.
+    trainingCandidates.forEach((candidate) => {
+      const { availability, intern } = candidate;
+      const trainer = internMap[availability.trainerId];
+      if (!trainer) {
+        return;
+      }
+      const trainerAvailability = availabilities.find((entry) => entry.internId === trainer.id && entry.day === day && timeToNumber(entry.start) <= numericHour && timeToNumber(entry.end) > numericHour);
+      if (!trainerAvailability) {
+        return;
+      }
+      if (!canPlaceParticipant(intern.id, key) || !canPlaceParticipant(trainer.id, key)) {
+        return;
+      }
+      slotAssignments.push({
+        id: generateId('assign'),
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        station: slotAssignments.length + 1,
+        internId: intern.id,
+        trainerId: trainer.id,
+        type: 'training',
+        source: 'auto'
+      });
+      assignedHours[intern.id] = (assignedHours[intern.id] || 0) + 1;
+      assignedHours[trainer.id] = (assignedHours[trainer.id] || 0) + 1;
+      markParticipants([intern.id, trainer.id], key);
+    });
+
+    const remainingCapacity = Math.max(maxStations - slotAssignments.length, 0);
+    const sortedIndependent = sortCandidates(independentCandidates);
+
+    const waitlisted = [];
+    sortedIndependent.forEach((candidate, index) => {
+      if (slotAssignments.length >= maxStations) {
+        waitlisted.push(candidate.intern.id);
+        return;
+      }
+      const { intern } = candidate;
+      if (!canPlaceParticipant(intern.id, key)) {
+        waitlisted.push(intern.id);
+        return;
+      }
+      slotAssignments.push({
+        id: generateId('assign'),
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        station: slotAssignments.length + 1,
+        internId: intern.id,
+        trainerId: null,
+        type: 'independent',
+        source: 'auto'
+      });
+      assignedHours[intern.id] = (assignedHours[intern.id] || 0) + 1;
+      markParticipants([intern.id], key);
+    });
+
+    if (waitlisted.length) {
+      waitlistedBySlot[key] = waitlisted;
+    }
+
+    slotAssignments.forEach((assignment) => {
+      assignments.push(assignment);
+    });
+
+    const open = Math.max(maxStations - slotAssignments.length, 0);
+    if (open > 0) {
+      openSlots.push({
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        availableStations: open
+      });
+    }
+  });
+
+  const totalsByIntern = interns.map((intern) => ({
+    internId: intern.id,
+    name: intern.name,
+    requestedHours: requestedHours[intern.id] || 0,
+    assignedHours: assignedHours[intern.id] || 0
+  }));
+
+  const daySummaries = {};
+  assignments.forEach((assignment) => {
+    if (!daySummaries[assignment.day]) {
+      daySummaries[assignment.day] = { assignments: 0, trainings: 0 };
+    }
+    daySummaries[assignment.day].assignments += 1;
+    if (assignment.type === 'training') {
+      daySummaries[assignment.day].trainings += 1;
+    }
+  });
+
+  return {
+    assignments,
+    openSlots,
+    totalsByIntern,
+    waitlistedBySlot,
+    daySummaries
+  };
+}
+
+function getAssignmentsByHour(assignments, day, start, end, ignoreId) {
+  const startNum = timeToNumber(start);
+  const endNum = timeToNumber(end);
+  return assignments.filter((assignment) => {
+    if (assignment.id === ignoreId) return false;
+    if (assignment.day !== day) return false;
+    const assignmentStart = timeToNumber(assignment.start);
+    const assignmentEnd = timeToNumber(assignment.end);
+    return assignmentStart < endNum && assignmentEnd > startNum;
+  });
+}
+
+function validateAssignmentPlacement(data, candidate, ignoreId = null) {
+  const { schedule, settings } = data;
+  const maxStations = settings?.maxStations || 9;
+  const assignments = schedule.assignments || [];
+  const participants = new Set([candidate.internId, candidate.trainerId].filter(Boolean));
+  const overlapping = getAssignmentsByHour(assignments, candidate.day, candidate.start, candidate.end, ignoreId);
+
+  for (const assignment of overlapping) {
+    const otherParticipants = new Set([assignment.internId, assignment.trainerId].filter(Boolean));
+    for (const participant of participants) {
+      if (otherParticipants.has(participant)) {
+        return { ok: false, reason: 'Participant is already assigned during this time block.' };
+      }
+    }
+  }
+
+  const hourSlots = getHourSlots(candidate.day, candidate.start, candidate.end);
+  for (const slot of hourSlots) {
+    const keyAssignments = overlapping.filter((assignment) => timeToNumber(assignment.start) <= slot.hour && timeToNumber(assignment.end) > slot.hour);
+    const stationCount = keyAssignments.length;
+    if (stationCount >= maxStations) {
+      return { ok: false, reason: 'All stations are occupied during at least one hour in this range.' };
+    }
+  }
+  return { ok: true };
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return;
+  }
+
+  try {
+    if (pathname === '/api/settings' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.settings || {});
+    }
+
+    if (pathname === '/api/interns' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.interns || []);
+    }
+
+    if (pathname === '/api/interns' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      if (!payload.name) {
+        return sendJSON(res, 400, { error: 'Name is required.' });
+      }
+      const data = readStore();
+      const intern = {
+        id: generateId('intern'),
+        name: payload.name,
+        isTrainer: Boolean(payload.isTrainer),
+        requiresTrainer: Boolean(payload.requiresTrainer)
+      };
+      data.interns.push(intern);
+      writeStore(data);
+      return sendJSON(res, 201, intern);
+    }
+
+    if (pathname === '/api/availabilities' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.availabilities || []);
+    }
+
+    if (pathname === '/api/availabilities' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      if (!payload.internId || !payload.day || !payload.start || !payload.end) {
+        return sendJSON(res, 400, { error: 'Intern, day, start and end are required.' });
+      }
+      const data = readStore();
+      const intern = data.interns.find((item) => item.id === payload.internId);
+      if (!intern) {
+        return sendJSON(res, 404, { error: 'Intern not found.' });
+      }
+      const startNum = timeToNumber(payload.start);
+      const endNum = timeToNumber(payload.end);
+      if (endNum <= startNum) {
+        return sendJSON(res, 400, { error: 'End time must be later than start time.' });
+      }
+      if (payload.sessionType === 'training' && !payload.trainerId) {
+        return sendJSON(res, 400, { error: 'Training sessions require a trainer.' });
+      }
+      const availability = {
+        id: generateId('availability'),
+        internId: payload.internId,
+        day: payload.day,
+        start: payload.start,
+        end: payload.end,
+        sessionType: payload.sessionType === 'training' ? 'training' : 'independent',
+        trainerId: payload.sessionType === 'training' ? payload.trainerId : null,
+        notes: payload.notes || ''
+      };
+      data.availabilities.push(availability);
+      writeStore(data);
+      return sendJSON(res, 201, availability);
+    }
+
+    if (pathname.startsWith('/api/availabilities/') && req.method === 'DELETE') {
+      const id = pathname.split('/').pop();
+      const data = readStore();
+      const before = data.availabilities.length;
+      data.availabilities = data.availabilities.filter((item) => item.id !== id);
+      if (data.availabilities.length === before) {
+        return sendJSON(res, 404, { error: 'Availability not found.' });
+      }
+      writeStore(data);
+      return sendJSON(res, 200, { success: true });
+    }
+
+    if (pathname === '/api/schedule' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.schedule || { assignments: [], openSlots: [] });
+    }
+
+    if (pathname === '/api/schedule/generate' && req.method === 'POST') {
+      const data = readStore();
+      const result = buildSchedule(data);
+      data.schedule = {
+        assignments: result.assignments,
+        openSlots: result.openSlots,
+        totalsByIntern: result.totalsByIntern,
+        waitlistedBySlot: result.waitlistedBySlot,
+        daySummaries: result.daySummaries,
+        generatedAt: new Date().toISOString()
+      };
+      writeStore(data);
+      return sendJSON(res, 200, data.schedule);
+    }
+
+    if (pathname.startsWith('/api/schedule/assignment/') && req.method === 'PUT') {
+      const id = pathname.split('/').pop();
+      const payload = await parseBody(req);
+      const data = readStore();
+      const assignment = data.schedule.assignments.find((item) => item.id === id);
+      if (!assignment) {
+        return sendJSON(res, 404, { error: 'Assignment not found.' });
+      }
+      const candidate = {
+        ...assignment,
+        day: payload.day || assignment.day,
+        start: payload.start || assignment.start,
+        end: payload.end || assignment.end,
+        station: payload.station || assignment.station
+      };
+      const validation = validateAssignmentPlacement(data, candidate, id);
+      if (!validation.ok) {
+        return sendJSON(res, 400, { error: validation.reason });
+      }
+      Object.assign(assignment, candidate, { source: 'manual' });
+      writeStore(data);
+      return sendJSON(res, 200, assignment);
+    }
+
+    if (pathname === '/api/schedule/assignment' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      const data = readStore();
+      if (!payload.internId || !payload.day || !payload.start || !payload.end) {
+        return sendJSON(res, 400, { error: 'Intern, day, start and end are required.' });
+      }
+      const assignment = {
+        id: generateId('assign'),
+        internId: payload.internId,
+        trainerId: payload.trainerId || null,
+        type: payload.trainerId ? 'training' : 'independent',
+        day: payload.day,
+        start: payload.start,
+        end: payload.end,
+        station: payload.station || (data.schedule.assignments.length % (data.settings?.maxStations || 9)) + 1,
+        source: 'manual'
+      };
+      const validation = validateAssignmentPlacement(data, assignment, null);
+      if (!validation.ok) {
+        return sendJSON(res, 400, { error: validation.reason });
+      }
+      data.schedule.assignments.push(assignment);
+      writeStore(data);
+      return sendJSON(res, 201, assignment);
+    }
+
+    if (pathname.startsWith('/api/schedule/assignment/') && req.method === 'DELETE') {
+      const id = pathname.split('/').pop();
+      const data = readStore();
+      const before = data.schedule.assignments.length;
+      data.schedule.assignments = data.schedule.assignments.filter((item) => item.id !== id);
+      if (data.schedule.assignments.length === before) {
+        return sendJSON(res, 404, { error: 'Assignment not found.' });
+      }
+      writeStore(data);
+      return sendJSON(res, 200, { success: true });
+    }
+
+    // Static assets
+    let filePath = path.join(CLIENT_DIR, pathname === '/' ? 'index.html' : pathname);
+    if (!filePath.startsWith(CLIENT_DIR)) {
+      return sendText(res, 403, 'Forbidden');
+    }
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        sendText(res, 404, 'Not Found');
+        return;
+      }
+      res.writeHead(200, {
+        'Content-Type': getMimeType(filePath),
+        'Access-Control-Allow-Origin': '*'
+      });
+      res.end(content);
+    });
+  } catch (error) {
+    console.error('Server error', error);
+    sendJSON(res, 500, { error: 'Internal server error', details: error.message });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Advance Scheduler API running on http://localhost:${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add a zero-dependency Node.js API that persists interns, availability, and generates fair station schedules with manual adjustment endpoints
- deliver a static FullCalendar-powered UI for collecting availability, managing schedules, and highlighting open slots with a modern design
- document project usage, API surface, and scheduling rules in the README

## Testing
- npm run lint
- node server/index.js & curl -s -X POST http://localhost:3000/api/schedule/generate | jq '{assignments: .assignments[:3], openSlots: .openSlots[:3]}'

------
https://chatgpt.com/codex/tasks/task_e_68d7087c75208329a0e9f0bdd17b78bc