### PR TITLE
feat: balance weekly scheduling distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-# Advance-scheduler
+# Advance Scheduler
+
+Advance Scheduler is a zero-dependency Node.js web application that collects intern availability, automatically generates a fair floor schedule across nine stations, and exposes a calendar interface for quick manual adjustments.
+
+## Features
+
+- **Availability intake** – interns submit the windows they can work, including optional trainer pairings for onboarding shifts.
+- **Intern-only availability portal** – dedicated submission page interns can open without exposing admin scheduling tools.
+- **Fair auto-scheduling** – balances requested hours against the nine-station capacity on an hour-by-hour basis while keeping training pairs on the same station.
+- **Open-slot surfacing** – highlights empty stations that can be offered to interns when capacity is available.
+- **FullCalendar interface** – drag-and-drop adjustments, duplication and removal of assignments directly from the calendar.
+- **Transparency dashboards** – summarize requested vs. assigned hours and day-by-day coverage to help maintain fairness.
+
+## Getting started
+
+1. **Install Node.js** (18+) locally.
+2. **Install dependencies** – the project is dependency-free so there is nothing to install.
+3. **Run the application**:
+
+   ```bash
+   npm start
+   ```
+
+4. **Open the UI**:
+
+   - Admin console: [http://localhost:3000](http://localhost:3000)
+   - Intern availability portal: [http://localhost:3000/availability.html](http://localhost:3000/availability.html)
+
+The API and the static frontend are served from the same Node.js process. All data is persisted inside `server/data/store.json`.
+
+## Intern availability portal
+
+- Share the `/availability.html` link with interns so they can submit their own time windows.
+- The portal only exposes the availability form and the intern's previously submitted entries—no scheduling dashboards are visible.
+- Training requests automatically require an available trainer before the submission is accepted.
+- Interns can queue multiple time windows in one visit and submit them together so complex days are captured in a single action.
+
+## API overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/interns` | List interns. |
+| POST | `/api/interns` | Create a new intern (`name`, `isTrainer`, `requiresTrainer`). |
+| GET | `/api/availabilities` | List availability submissions. |
+| POST | `/api/availabilities` | Submit availability for one or more windows. Accepts a single window (`internId`, `day`, `start`, `end`, `sessionType`, optional `trainerId`) or `{ internId, entries: [...] }` to save several at once. |
+| DELETE | `/api/availabilities/:id` | Remove an availability entry. |
+| POST | `/api/schedule/generate` | Generate a new schedule using current availability. |
+| GET | `/api/schedule` | Fetch the latest generated schedule and open slot summary. |
+| PUT | `/api/schedule/assignment/:id` | Manually adjust an assignment (day, start, end, station). |
+| POST | `/api/schedule/assignment` | Create a manual assignment or duplicate an existing one. |
+| DELETE | `/api/schedule/assignment/:id` | Delete an assignment from the schedule. |
+
+## Scheduling logic
+
+- Time is evaluated in one-hour blocks between 07:00 and 22:00.
+- A maximum of nine stations may be active each hour; training pairs share a station while counting both the trainee and the trainer toward fairness metrics.
+- Candidates for each hour are sorted by their assigned/requested hour ratio, ensuring interns with fewer assigned hours are prioritized.
+- The generator also tracks hours awarded per day so interns who have not yet worked that day are prioritized before doubling up on the same people.
+- Trainers must have overlapping availability to cover a training request; otherwise the session is skipped.
+- The generator records waitlisted interns for any hour that exceeds the station limit and surfaces empty stations as actionable open slots.
+
+## Data persistence
+
+All data lives in `server/data/store.json`. Back up this file before redeploying if you want to preserve historical submissions.
+
+The repository ships with a representative demo roster covering Monday–Friday so the scheduler immediately showcases even distribution across the week. Feel free to clear the file contents or replace them with your own data when moving to production.
+
+## Development notes
+
+- The UI uses the CDN build of [FullCalendar](https://fullcalendar.io/) and modern CSS for styling.
+- The server relies solely on Node.js core modules to simplify deployment in restricted environments.
+- Feel free to extend the generator with additional fairness rules (e.g., prioritizing trainees, minimum weekly hours) as business requirements evolve.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "advance-scheduler",
+  "version": "1.0.0",
+  "description": "Web scheduler to balance intern availability with station capacity",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "lint": "node --check server/index.js"
+  },
+  "keywords": ["scheduler", "interns", "calendar"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,425 @@
+const API_BASE = '';
+
+const calendarElement = document.getElementById('calendar');
+const availabilityTableBody = document.getElementById('availabilityTableBody');
+const internForm = document.getElementById('internForm');
+const availabilityForm = document.getElementById('availabilityForm');
+const internSelect = document.getElementById('availabilityIntern');
+const trainerSelect = document.getElementById('trainerSelect');
+const trainerField = document.getElementById('trainerField');
+const availabilityTypeSelect = document.getElementById('availabilityType');
+const availabilityRowTemplate = document.getElementById('availabilityRowTemplate');
+const generateButton = document.getElementById('generateSchedule');
+const openSlotsList = document.getElementById('openSlots');
+const summaryTableBody = document.getElementById('summaryTableBody');
+const daySummaryBody = document.getElementById('daySummaryBody');
+const lastGeneratedLabel = document.getElementById('lastGenerated');
+const duplicateButton = document.getElementById('duplicateAssignment');
+const deleteButton = document.getElementById('deleteAssignment');
+
+let interns = [];
+let availabilities = [];
+let schedule = { assignments: [], openSlots: [], totalsByIntern: [] };
+let calendar;
+let selectedEventId = null;
+
+function dayToDate(dayName) {
+  const now = new Date();
+  const currentDay = now.getDay();
+  const desiredDay = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].indexOf(dayName);
+  if (desiredDay === -1) return now;
+  const distance = (desiredDay + 7 - currentDay) % 7;
+  const target = new Date(now);
+  target.setDate(now.getDate() + distance);
+  target.setHours(0, 0, 0, 0);
+  return target;
+}
+
+function toCalendarEvent(assignment) {
+  const intern = interns.find((item) => item.id === assignment.internId);
+  const trainer = assignment.trainerId ? interns.find((item) => item.id === assignment.trainerId) : null;
+  const startDate = dayToDate(assignment.day);
+  const [startHour, startMinute] = assignment.start.split(':').map(Number);
+  const [endHour, endMinute] = assignment.end.split(':').map(Number);
+  const start = new Date(startDate);
+  start.setHours(startHour, startMinute, 0, 0);
+  const end = new Date(startDate);
+  end.setHours(endHour, endMinute, 0, 0);
+
+  const titleParts = [];
+  if (intern) titleParts.push(intern.name);
+  if (trainer) titleParts.push(`+ ${trainer.name}`);
+  const title = titleParts.join(' ');
+
+  return {
+    id: assignment.id,
+    title: title || 'Unassigned',
+    start,
+    end,
+    extendedProps: {
+      station: assignment.station,
+      type: assignment.type,
+      internId: assignment.internId,
+      trainerId: assignment.trainerId || null,
+      day: assignment.day
+    },
+    classNames: [assignment.type === 'training' ? 'training-event' : 'independent-event']
+  };
+}
+
+function renderCalendar() {
+  if (calendar) {
+    calendar.destroy();
+  }
+  calendar = new FullCalendar.Calendar(calendarElement, {
+    initialView: 'timeGridWeek',
+    nowIndicator: true,
+    slotMinTime: '06:00:00',
+    slotMaxTime: '22:00:00',
+    allDaySlot: false,
+    editable: true,
+    droppable: false,
+    eventDurationEditable: false,
+    firstDay: 1,
+    dayHeaderFormat: { weekday: 'long' },
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'timeGridWeek,timeGridDay'
+    },
+    events: schedule.assignments.map(toCalendarEvent),
+    eventClick(info) {
+      selectedEventId = info.event.id;
+      duplicateButton.disabled = false;
+      deleteButton.disabled = false;
+    },
+    eventDrop(info) {
+      const event = info.event;
+      persistEventUpdate(event).catch((error) => {
+        alert(error.message || 'Unable to update assignment.');
+        info.revert();
+      });
+    }
+  });
+  calendar.render();
+}
+
+async function persistEventUpdate(event) {
+  const body = buildPayloadFromEvent(event);
+  const response = await fetch(`${API_BASE}/api/schedule/assignment/${event.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.error || 'Failed to update assignment');
+  }
+  await refreshSchedule();
+}
+
+function buildPayloadFromEvent(event) {
+  const start = event.start;
+  const end = event.end;
+  const day = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][start.getDay()];
+  const toTimeString = (date) => `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+  return {
+    day,
+    start: toTimeString(start),
+    end: toTimeString(end)
+  };
+}
+
+async function loadInterns() {
+  const response = await fetch(`${API_BASE}/api/interns`);
+  interns = await response.json();
+  renderInternOptions();
+}
+
+function renderInternOptions() {
+  internSelect.innerHTML = '';
+  trainerSelect.innerHTML = '<option value="">Select trainer</option>';
+  interns.forEach((intern) => {
+    const option = document.createElement('option');
+    option.value = intern.id;
+    option.textContent = intern.name;
+    internSelect.appendChild(option);
+    if (intern.isTrainer) {
+      const trainerOption = document.createElement('option');
+      trainerOption.value = intern.id;
+      trainerOption.textContent = intern.name;
+      trainerSelect.appendChild(trainerOption);
+    }
+  });
+}
+
+async function loadAvailabilities() {
+  const response = await fetch(`${API_BASE}/api/availabilities`);
+  availabilities = await response.json();
+  renderAvailabilityTable();
+}
+
+function renderAvailabilityTable() {
+  availabilityTableBody.innerHTML = '';
+  availabilities
+    .sort((a, b) => {
+      const internA = interns.find((item) => item.id === a.internId)?.name || '';
+      const internB = interns.find((item) => item.id === b.internId)?.name || '';
+      if (internA !== internB) return internA.localeCompare(internB);
+      if (a.day !== b.day) return a.day.localeCompare(b.day);
+      return a.start.localeCompare(b.start);
+    })
+    .forEach((availability) => {
+      const clone = availabilityRowTemplate.content.cloneNode(true);
+      clone.querySelector('.availability-name').textContent = interns.find((intern) => intern.id === availability.internId)?.name || '';
+      clone.querySelector('.availability-day').textContent = availability.day;
+      clone.querySelector('.availability-time').textContent = `${availability.start} – ${availability.end}`;
+      clone.querySelector('.availability-type').textContent = availability.sessionType === 'training' ? 'Training' : 'Independent';
+      const deleteButton = clone.querySelector('button');
+      deleteButton.addEventListener('click', () => deleteAvailability(availability.id));
+      availabilityTableBody.appendChild(clone);
+    });
+}
+
+async function deleteAvailability(id) {
+  const confirmed = confirm('Remove this availability entry?');
+  if (!confirmed) return;
+  await fetch(`${API_BASE}/api/availabilities/${id}`, { method: 'DELETE' });
+  await loadAvailabilities();
+}
+
+async function refreshSchedule() {
+  const response = await fetch(`${API_BASE}/api/schedule`);
+  schedule = await response.json();
+  updateLastGenerated();
+  renderCalendar();
+  renderOpenSlots();
+  renderSummary();
+  renderDaySummary();
+}
+
+function renderOpenSlots() {
+  openSlotsList.innerHTML = '';
+  if (!schedule.openSlots || schedule.openSlots.length === 0) {
+    const empty = document.createElement('li');
+    empty.textContent = 'All stations filled in scheduled hours.';
+    openSlotsList.appendChild(empty);
+    return;
+  }
+  schedule.openSlots.forEach((slot) => {
+    const item = document.createElement('li');
+    const label = `${slot.day} · ${slot.start} – ${slot.end}`;
+    item.innerHTML = `<span>${label}</span><span>${slot.availableStations} open</span>`;
+    openSlotsList.appendChild(item);
+  });
+}
+
+function renderSummary() {
+  summaryTableBody.innerHTML = '';
+  const totals = schedule.totalsByIntern || [];
+  if (totals.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 3;
+    cell.textContent = 'No assignments yet.';
+    row.appendChild(cell);
+    summaryTableBody.appendChild(row);
+    return;
+  }
+
+  totals
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${row.name}</td>`;
+      const requestedCell = document.createElement('td');
+      requestedCell.textContent = row.requestedHours;
+      const assignedCell = document.createElement('td');
+      assignedCell.textContent = row.assignedHours;
+      tr.appendChild(requestedCell);
+      tr.appendChild(assignedCell);
+      summaryTableBody.appendChild(tr);
+    });
+}
+
+function renderDaySummary() {
+  if (!daySummaryBody) return;
+  daySummaryBody.innerHTML = '';
+  const daySummaries = schedule.daySummaries || {};
+  const orderedDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+  let hasData = false;
+
+  orderedDays.forEach((day) => {
+    const summary = daySummaries[day];
+    if (!summary) return;
+    hasData = true;
+    const row = document.createElement('tr');
+    const dayCell = document.createElement('td');
+    dayCell.textContent = day;
+    row.appendChild(dayCell);
+    const assignmentsCell = document.createElement('td');
+    assignmentsCell.textContent = summary.assignments;
+    row.appendChild(assignmentsCell);
+    const trainingCell = document.createElement('td');
+    trainingCell.textContent = summary.trainings;
+    row.appendChild(trainingCell);
+    daySummaryBody.appendChild(row);
+  });
+
+  if (!hasData) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 3;
+    cell.textContent = 'Generate a schedule to view distribution by day.';
+    row.appendChild(cell);
+    daySummaryBody.appendChild(row);
+  }
+}
+
+function updateLastGenerated() {
+  if (!schedule.generatedAt) {
+    lastGeneratedLabel.textContent = 'No schedule generated yet.';
+    return;
+  }
+  const formatted = new Date(schedule.generatedAt).toLocaleString();
+  lastGeneratedLabel.textContent = `Generated on ${formatted}`;
+}
+
+async function generateSchedule() {
+  generateButton.disabled = true;
+  generateButton.textContent = 'Generating…';
+  try {
+    const response = await fetch(`${API_BASE}/api/schedule/generate`, { method: 'POST' });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(error.error || 'Failed to generate schedule');
+    }
+    schedule = await response.json();
+    updateLastGenerated();
+    renderCalendar();
+    renderOpenSlots();
+    renderSummary();
+    renderDaySummary();
+  } catch (error) {
+    alert(error.message);
+  } finally {
+    generateButton.disabled = false;
+    generateButton.textContent = 'Generate fresh schedule';
+  }
+}
+
+async function createIntern(event) {
+  event.preventDefault();
+  const name = document.getElementById('internName').value.trim();
+  if (!name) return;
+  const payload = {
+    name,
+    isTrainer: document.getElementById('internTrainer').checked,
+    requiresTrainer: document.getElementById('internRequiresTrainer').checked
+  };
+  const response = await fetch(`${API_BASE}/api/interns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    alert('Unable to add intern');
+    return;
+  }
+  document.getElementById('internName').value = '';
+  document.getElementById('internTrainer').checked = false;
+  document.getElementById('internRequiresTrainer').checked = false;
+  await loadInterns();
+}
+
+async function submitAvailability(event) {
+  event.preventDefault();
+  const payload = {
+    internId: internSelect.value,
+    day: document.getElementById('availabilityDay').value,
+    start: document.getElementById('availabilityStart').value,
+    end: document.getElementById('availabilityEnd').value,
+    sessionType: availabilityTypeSelect.value,
+    trainerId: availabilityTypeSelect.value === 'training' ? trainerSelect.value : null,
+    notes: document.getElementById('availabilityNotes').value.trim()
+  };
+  const response = await fetch(`${API_BASE}/api/availabilities`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unable to submit availability' }));
+    alert(error.error || 'Unable to submit availability');
+    return;
+  }
+  availabilityForm.reset();
+  trainerField.hidden = true;
+  await loadAvailabilities();
+}
+
+function handleSessionTypeChange() {
+  const type = availabilityTypeSelect.value;
+  if (type === 'training') {
+    trainerField.hidden = false;
+  } else {
+    trainerField.hidden = true;
+  }
+}
+
+async function duplicateSelectedAssignment() {
+  if (!selectedEventId) return;
+  const event = calendar.getEventById(selectedEventId);
+  if (!event) return;
+  const payload = buildPayloadFromEvent(event);
+  payload.internId = event.extendedProps.internId;
+  payload.trainerId = event.extendedProps.trainerId;
+  payload.station = event.extendedProps.station;
+  const response = await fetch(`${API_BASE}/api/schedule/assignment`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unable to duplicate assignment' }));
+    alert(error.error || 'Unable to duplicate assignment');
+    return;
+  }
+  await refreshSchedule();
+}
+
+async function deleteSelectedAssignment() {
+  if (!selectedEventId) return;
+  const confirmed = confirm('Delete this assignment from the schedule?');
+  if (!confirmed) return;
+  const response = await fetch(`${API_BASE}/api/schedule/assignment/${selectedEventId}`, {
+    method: 'DELETE'
+  });
+  if (!response.ok) {
+    alert('Unable to delete assignment');
+    return;
+  }
+  selectedEventId = null;
+  duplicateButton.disabled = true;
+  deleteButton.disabled = true;
+  await refreshSchedule();
+}
+
+function attachEventHandlers() {
+  internForm.addEventListener('submit', createIntern);
+  availabilityForm.addEventListener('submit', submitAvailability);
+  availabilityTypeSelect.addEventListener('change', handleSessionTypeChange);
+  generateButton.addEventListener('click', generateSchedule);
+  duplicateButton.addEventListener('click', duplicateSelectedAssignment);
+  deleteButton.addEventListener('click', deleteSelectedAssignment);
+}
+
+async function bootstrap() {
+  attachEventHandlers();
+  await loadInterns();
+  await loadAvailabilities();
+  await refreshSchedule();
+}
+
+bootstrap();

--- a/public/availability.html
+++ b/public/availability.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Intern Availability Portal</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Intern Availability Portal</h1>
+        <p class="tagline">Share your preferred hours without accessing the admin console.</p>
+      </div>
+      <a class="link-button secondary" href="index.html">Back to admin tools</a>
+    </header>
+
+    <main class="availability-layout">
+      <section class="panel">
+        <h2>Submit your available hours</h2>
+        <p class="availability-intro">
+          Choose your name, pick a day, and share the time window you would like to work. If you still require a trainer, switch the
+          session type and select the trainer who will accompany you. You can return to this page to review or remove your own
+          submissions at any time.
+        </p>
+
+        <div id="status" class="status-message" hidden></div>
+
+        <form id="availabilityForm" class="form">
+          <div class="form-field">
+            <label for="availabilityIntern">Your name</label>
+            <select id="availabilityIntern" required>
+              <option value="">Select your name</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label for="availabilityDay">Day</label>
+              <select id="availabilityDay" required>
+                <option value="Monday">Monday</option>
+                <option value="Tuesday">Tuesday</option>
+                <option value="Wednesday">Wednesday</option>
+                <option value="Thursday">Thursday</option>
+                <option value="Friday">Friday</option>
+                <option value="Saturday">Saturday</option>
+                <option value="Sunday">Sunday</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="availabilityStart">Start time</label>
+              <input type="time" id="availabilityStart" min="06:00" max="22:00" required />
+            </div>
+            <div class="form-field">
+              <label for="availabilityEnd">End time</label>
+              <input type="time" id="availabilityEnd" min="07:00" max="23:00" required />
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="availabilityType">Session type</label>
+            <select id="availabilityType">
+              <option value="independent">Independent</option>
+              <option value="training">Training (requires trainer)</option>
+            </select>
+          </div>
+          <div class="form-field" id="trainerField" hidden>
+            <label for="trainerSelect">Trainer</label>
+            <select id="trainerSelect">
+              <option value="">Select a trainer</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="availabilityNotes">Notes <span class="hint">(optional)</span></label>
+            <textarea id="availabilityNotes" rows="2" placeholder="Include course breaks or context if needed"></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="button" id="addWindowButton" class="secondary">Add time window</button>
+            <button type="submit" id="submitAvailabilityButton" class="primary">Submit windows</button>
+          </div>
+        </form>
+
+        <div class="pending-section" id="pendingSection" hidden>
+          <h3>Windows ready to submit</h3>
+          <ul id="pendingList" class="pending-list"></ul>
+          <p class="hint">All listed windows will be saved together when you submit.</p>
+        </div>
+
+        <div class="availability-table" id="availabilityTable" hidden>
+          <h3>Your submitted windows</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Time</th>
+                <th>Type</th>
+                <th class="actions"></th>
+              </tr>
+            </thead>
+            <tbody id="availabilityTableBody"></tbody>
+          </table>
+          <p class="empty-state" id="emptyState" hidden>No availability has been submitted yet.</p>
+        </div>
+      </section>
+    </main>
+
+    <template id="availabilityRowTemplate">
+      <tr>
+        <td class="availability-day"></td>
+        <td class="availability-time"></td>
+        <td class="availability-type"></td>
+        <td class="actions"><button class="danger small" type="button">Remove</button></td>
+      </tr>
+    </template>
+
+    <template id="pendingWindowTemplate">
+      <li class="pending-item">
+        <div class="pending-item-details">
+          <p class="pending-item-time"></p>
+          <p class="pending-item-meta"></p>
+          <p class="pending-item-notes" hidden></p>
+        </div>
+        <button type="button" class="danger small">Remove</button>
+      </li>
+    </template>
+
+    <script src="availability.js" type="module"></script>
+  </body>
+</html>

--- a/public/availability.js
+++ b/public/availability.js
@@ -1,0 +1,414 @@
+const API_BASE = '';
+
+const internSelect = document.getElementById('availabilityIntern');
+const daySelect = document.getElementById('availabilityDay');
+const startInput = document.getElementById('availabilityStart');
+const endInput = document.getElementById('availabilityEnd');
+const typeSelect = document.getElementById('availabilityType');
+const notesInput = document.getElementById('availabilityNotes');
+const trainerField = document.getElementById('trainerField');
+const trainerSelect = document.getElementById('trainerSelect');
+const availabilityForm = document.getElementById('availabilityForm');
+const statusElement = document.getElementById('status');
+const availabilityTable = document.getElementById('availabilityTable');
+const availabilityTableBody = document.getElementById('availabilityTableBody');
+const emptyState = document.getElementById('emptyState');
+const availabilityRowTemplate = document.getElementById('availabilityRowTemplate');
+const addWindowButton = document.getElementById('addWindowButton');
+const submitAvailabilityButton = document.getElementById('submitAvailabilityButton');
+const pendingSection = document.getElementById('pendingSection');
+const pendingList = document.getElementById('pendingList');
+const pendingWindowTemplate = document.getElementById('pendingWindowTemplate');
+
+const dependentControls = Array.from(availabilityForm.querySelectorAll('input, textarea, select, button')).filter(
+  (element) => element.id !== 'availabilityIntern'
+);
+
+let interns = [];
+let availabilities = [];
+let selectedInternId = '';
+let pendingWindows = [];
+
+function timeToMinutes(time) {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+function showStatus(message, type = 'info') {
+  statusElement.textContent = message;
+  statusElement.className = 'status-message';
+  if (type === 'success') {
+    statusElement.classList.add('success');
+  } else if (type === 'error') {
+    statusElement.classList.add('error');
+  }
+  statusElement.hidden = false;
+}
+
+function clearStatus() {
+  statusElement.hidden = true;
+  statusElement.textContent = '';
+  statusElement.className = 'status-message';
+}
+
+function setDependentControlsEnabled(enabled) {
+  dependentControls.forEach((element) => {
+    element.disabled = !enabled;
+  });
+  updatePendingSection();
+}
+
+function clearPendingWindows() {
+  pendingWindows = [];
+  updatePendingSection();
+}
+
+function removePendingWindow(index) {
+  pendingWindows.splice(index, 1);
+  updatePendingSection();
+}
+
+function updatePendingSection() {
+  if (!pendingList || !pendingSection || !submitAvailabilityButton || !pendingWindowTemplate) {
+    return;
+  }
+
+  pendingList.innerHTML = '';
+
+  if (!selectedInternId || pendingWindows.length === 0) {
+    pendingSection.hidden = true;
+    submitAvailabilityButton.disabled = !selectedInternId;
+    return;
+  }
+
+  pendingSection.hidden = false;
+
+  pendingWindows.forEach((entry, index) => {
+    const fragment = pendingWindowTemplate.content.cloneNode(true);
+    fragment.querySelector('.pending-item-time').textContent = `${entry.day}: ${entry.start} – ${entry.end}`;
+    const metaParts = [];
+    const typeLabel = entry.sessionType === 'training' ? 'Training' : 'Independent';
+    metaParts.push(typeLabel);
+    if (entry.sessionType === 'training' && entry.trainerId) {
+      const trainerName = interns.find((intern) => intern.id === entry.trainerId)?.name || 'Trainer';
+      metaParts.push(`Trainer: ${trainerName}`);
+    }
+    fragment.querySelector('.pending-item-meta').textContent = metaParts.join(' • ');
+    const notesElement = fragment.querySelector('.pending-item-notes');
+    if (entry.notes) {
+      notesElement.textContent = entry.notes;
+      notesElement.hidden = false;
+    } else {
+      notesElement.hidden = true;
+    }
+    const removeButton = fragment.querySelector('button');
+    removeButton.addEventListener('click', () => removePendingWindow(index));
+    pendingList.appendChild(fragment);
+  });
+
+  submitAvailabilityButton.disabled = false;
+}
+
+function buildEntryFromForm() {
+  const start = startInput.value;
+  const end = endInput.value;
+
+  if (!start || !end) {
+    showStatus('Select both a start and end time before continuing.', 'error');
+    return null;
+  }
+
+  if (timeToMinutes(end) <= timeToMinutes(start)) {
+    showStatus('End time must be later than start time.', 'error');
+    return null;
+  }
+
+  const sessionType = typeSelect.value;
+  const isTraining = sessionType === 'training';
+  if (isTraining && !trainerSelect.value) {
+    showStatus('Select a trainer to include a training session.', 'error');
+    return null;
+  }
+
+  return {
+    day: daySelect.value,
+    start,
+    end,
+    sessionType,
+    trainerId: isTraining ? trainerSelect.value : null,
+    notes: notesInput.value.trim()
+  };
+}
+
+function renderInternOptions() {
+  const previousSelection = internSelect.value;
+  internSelect.innerHTML = '<option value="">Select your name</option>';
+  const sorted = [...interns].sort((a, b) => a.name.localeCompare(b.name));
+  sorted.forEach((intern) => {
+    const option = document.createElement('option');
+    option.value = intern.id;
+    option.textContent = intern.name;
+    internSelect.appendChild(option);
+  });
+
+  if (interns.some((intern) => intern.id === previousSelection)) {
+    internSelect.value = previousSelection;
+    selectedInternId = previousSelection;
+  } else {
+    internSelect.value = '';
+    selectedInternId = '';
+  }
+}
+
+function renderTrainerOptions() {
+  trainerSelect.innerHTML = '<option value="">Select a trainer</option>';
+  const trainers = interns.filter((intern) => intern.isTrainer);
+  trainers.forEach((trainer) => {
+    const option = document.createElement('option');
+    option.value = trainer.id;
+    option.textContent = trainer.name;
+    trainerSelect.appendChild(option);
+  });
+  trainerSelect.disabled = trainers.length === 0;
+}
+
+function evaluateFormState() {
+  if (interns.length === 0) {
+    internSelect.disabled = true;
+    setDependentControlsEnabled(false);
+    showStatus('No interns are available yet. Please contact an administrator to be added before submitting availability.', 'error');
+    availabilityTable.hidden = true;
+    return;
+  }
+
+  internSelect.disabled = false;
+  const hasSelection = Boolean(selectedInternId);
+  setDependentControlsEnabled(hasSelection);
+  if (!hasSelection) {
+    clearPendingWindows();
+    availabilityTable.hidden = true;
+  }
+}
+
+function renderAvailabilityTable() {
+  if (!selectedInternId) {
+    availabilityTable.hidden = true;
+    return;
+  }
+
+  const entries = availabilities
+    .filter((availability) => availability.internId === selectedInternId)
+    .sort((a, b) => {
+      if (a.day !== b.day) return a.day.localeCompare(b.day);
+      return a.start.localeCompare(b.start);
+    });
+
+  availabilityTable.hidden = false;
+  availabilityTableBody.innerHTML = '';
+
+  if (entries.length === 0) {
+    emptyState.hidden = false;
+    return;
+  }
+
+  emptyState.hidden = true;
+
+  entries.forEach((availability) => {
+    const fragment = availabilityRowTemplate.content.cloneNode(true);
+    fragment.querySelector('.availability-day').textContent = availability.day;
+    fragment.querySelector('.availability-time').textContent = `${availability.start} – ${availability.end}`;
+    const typeLabel = availability.sessionType === 'training' ? 'Training' : 'Independent';
+    const trainerName = availability.trainerId
+      ? interns.find((intern) => intern.id === availability.trainerId)?.name || 'Trainer'
+      : null;
+    fragment.querySelector('.availability-type').textContent = trainerName ? `${typeLabel} (${trainerName})` : typeLabel;
+    const deleteButton = fragment.querySelector('button');
+    deleteButton.addEventListener('click', () => {
+      deleteAvailability(availability.id, deleteButton);
+    });
+    availabilityTableBody.appendChild(fragment);
+  });
+}
+
+async function loadInterns() {
+  try {
+    const response = await fetch(`${API_BASE}/api/interns`);
+    if (!response.ok) {
+      throw new Error('Unable to load intern list.');
+    }
+    interns = await response.json();
+    renderInternOptions();
+    renderTrainerOptions();
+    evaluateFormState();
+    renderAvailabilityTable();
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message || 'Unable to load intern list.', 'error');
+    internSelect.disabled = true;
+    setDependentControlsEnabled(false);
+  }
+}
+
+async function loadAvailabilities() {
+  try {
+    const response = await fetch(`${API_BASE}/api/availabilities`);
+    if (!response.ok) {
+      throw new Error('Unable to load availability.');
+    }
+    availabilities = await response.json();
+    renderAvailabilityTable();
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message || 'Unable to load availability.', 'error');
+  }
+}
+
+async function submitAvailability(event) {
+  event.preventDefault();
+  clearStatus();
+
+  if (!selectedInternId) {
+    showStatus('Please choose your name before submitting availability.', 'error');
+    return;
+  }
+
+  let entriesToSubmit = [...pendingWindows];
+  if (entriesToSubmit.length === 0) {
+    const singleEntry = buildEntryFromForm();
+    if (!singleEntry) {
+      return;
+    }
+    entriesToSubmit = [singleEntry];
+  }
+
+  const payload = {
+    internId: selectedInternId,
+    entries: entriesToSubmit.map((entry) => ({
+      day: entry.day,
+      start: entry.start,
+      end: entry.end,
+      sessionType: entry.sessionType,
+      trainerId: entry.sessionType === 'training' ? entry.trainerId : null,
+      notes: entry.notes || ''
+    }))
+  };
+
+  submitAvailabilityButton.disabled = true;
+
+  try {
+    const response = await fetch(`${API_BASE}/api/availabilities`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unable to submit availability.' }));
+      throw new Error(error.error || 'Unable to submit availability.');
+    }
+
+    const result = await response.json().catch(() => ({}));
+    const count = Array.isArray(result.created)
+      ? result.created.length
+      : result && typeof result === 'object' && result.id
+      ? 1
+      : payload.entries.length;
+    const windowLabel = count === 1 ? 'availability window' : 'availability windows';
+    showStatus(`Successfully submitted ${count} ${windowLabel}.`, 'success');
+    clearPendingWindows();
+    await loadAvailabilities();
+    resetFormFields();
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message || 'Unable to submit availability.', 'error');
+  } finally {
+    submitAvailabilityButton.disabled = false;
+  }
+}
+
+function resetFormFields() {
+  startInput.value = '';
+  endInput.value = '';
+  notesInput.value = '';
+  typeSelect.value = 'independent';
+  trainerSelect.value = '';
+  trainerField.hidden = true;
+}
+
+function handleAddWindow() {
+  clearStatus();
+  if (!selectedInternId) {
+    showStatus('Choose your name before adding time windows.', 'error');
+    return;
+  }
+
+  const entry = buildEntryFromForm();
+  if (!entry) {
+    return;
+  }
+
+  pendingWindows.push(entry);
+  updatePendingSection();
+  showStatus(`Added ${entry.day} ${entry.start} – ${entry.end} to the submission list.`, 'success');
+  resetFormFields();
+}
+
+async function deleteAvailability(id, button) {
+  const confirmed = confirm('Remove this availability entry?');
+  if (!confirmed) {
+    return;
+  }
+
+  button.disabled = true;
+  try {
+    const response = await fetch(`${API_BASE}/api/availabilities/${id}`, { method: 'DELETE' });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unable to remove availability.' }));
+      throw new Error(error.error || 'Unable to remove availability.');
+    }
+    showStatus('Availability removed.', 'success');
+    await loadAvailabilities();
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message || 'Unable to remove availability.', 'error');
+  } finally {
+    button.disabled = false;
+  }
+}
+
+function handleInternChange() {
+  const previousInternId = selectedInternId;
+  selectedInternId = internSelect.value;
+  clearStatus();
+  setDependentControlsEnabled(Boolean(selectedInternId));
+  if (!selectedInternId || selectedInternId !== previousInternId) {
+    clearPendingWindows();
+  }
+  renderAvailabilityTable();
+  if (selectedInternId) {
+    showStatus(`You are updating availability for ${internSelect.options[internSelect.selectedIndex].textContent}.`);
+  }
+}
+
+function handleTypeChange() {
+  const isTraining = typeSelect.value === 'training';
+  trainerField.hidden = !isTraining;
+  if (isTraining) {
+    renderTrainerOptions();
+    if (trainerSelect.disabled) {
+      showStatus('No trainers are currently available. Please submit this session after a trainer is added.', 'error');
+    }
+  } else {
+    trainerSelect.value = '';
+  }
+}
+
+availabilityForm.addEventListener('submit', submitAvailability);
+if (addWindowButton) {
+  addWindowButton.addEventListener('click', handleAddWindow);
+}
+internSelect.addEventListener('change', handleInternChange);
+typeSelect.addEventListener('change', handleTypeChange);
+
+renderTrainerOptions();
+setDependentControlsEnabled(false);
+loadInterns().then(loadAvailabilities);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Advance Scheduler</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Advance Scheduler</h1>
+        <p class="tagline">Balance availability requests with real-time station capacity.</p>
+      </div>
+      <div class="header-actions">
+        <a class="link-button secondary" href="availability.html">Intern portal</a>
+        <button id="generateSchedule" class="primary">Generate fresh schedule</button>
+        <span id="lastGenerated" class="timestamp"></span>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel" id="availabilityPanel">
+        <h2>1. Manage interns</h2>
+        <form id="internForm" class="form">
+          <div class="form-field">
+            <label for="internName">Intern name</label>
+            <input type="text" id="internName" name="internName" placeholder="e.g. A. Forbes" required />
+          </div>
+          <div class="form-row">
+            <label class="checkbox">
+              <input type="checkbox" id="internTrainer" />
+              <span>Trainer</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="internRequiresTrainer" />
+              <span>Requires trainer</span>
+            </label>
+          </div>
+          <button type="submit" class="secondary">Add intern</button>
+        </form>
+
+        <h2>2. Collect availability</h2>
+        <form id="availabilityForm" class="form">
+          <div class="form-field">
+            <label for="availabilityIntern">Intern</label>
+            <select id="availabilityIntern" required></select>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label for="availabilityDay">Day</label>
+              <select id="availabilityDay" required>
+                <option value="Monday">Monday</option>
+                <option value="Tuesday">Tuesday</option>
+                <option value="Wednesday">Wednesday</option>
+                <option value="Thursday">Thursday</option>
+                <option value="Friday">Friday</option>
+                <option value="Saturday">Saturday</option>
+                <option value="Sunday">Sunday</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="availabilityStart">Start</label>
+              <input type="time" id="availabilityStart" min="06:00" max="22:00" required />
+            </div>
+            <div class="form-field">
+              <label for="availabilityEnd">End</label>
+              <input type="time" id="availabilityEnd" min="07:00" max="23:00" required />
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="availabilityType">Session type</label>
+            <select id="availabilityType">
+              <option value="independent">Independent</option>
+              <option value="training">Training (requires trainer)</option>
+            </select>
+          </div>
+          <div class="form-field" id="trainerField" hidden>
+            <label for="trainerSelect">Trainer</label>
+            <select id="trainerSelect"></select>
+          </div>
+          <div class="form-field">
+            <label for="availabilityNotes">Notes</label>
+            <textarea id="availabilityNotes" rows="2" placeholder="Optional context or requests"></textarea>
+          </div>
+          <button type="submit" class="primary">Submit availability</button>
+        </form>
+
+        <div class="availability-table">
+          <h3>Submitted availability</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Intern</th>
+                <th>Day</th>
+                <th>Time</th>
+                <th>Type</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="availabilityTableBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" id="schedulePanel">
+        <div class="panel-header">
+          <h2>3. Curate the floor schedule</h2>
+          <div class="legend">
+            <span class="badge independent">Independent</span>
+            <span class="badge training">Training pair</span>
+          </div>
+        </div>
+        <div id="calendar"></div>
+
+        <div class="panel-footer">
+          <div>
+            <h3>Open station slots</h3>
+            <ul id="openSlots"></ul>
+          </div>
+          <div>
+            <h3>Fairness overview</h3>
+            <table class="summary-table">
+              <thead>
+                <tr>
+                  <th>Intern</th>
+                  <th>Requested</th>
+                  <th>Assigned</th>
+                </tr>
+              </thead>
+              <tbody id="summaryTableBody"></tbody>
+            </table>
+          </div>
+          <div>
+            <h3>Daily coverage</h3>
+            <table class="summary-table">
+              <thead>
+                <tr>
+                  <th>Day</th>
+                  <th>Assignments</th>
+                  <th>Training pairs</th>
+                </tr>
+              </thead>
+              <tbody id="daySummaryBody"></tbody>
+            </table>
+          </div>
+          <div>
+            <h3>Event controls</h3>
+            <div class="actions">
+              <button id="duplicateAssignment" class="secondary" disabled>Duplicate selected</button>
+              <button id="deleteAssignment" class="danger" disabled>Delete selected</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <template id="availabilityRowTemplate">
+      <tr>
+        <td class="availability-name"></td>
+        <td class="availability-day"></td>
+        <td class="availability-time"></td>
+        <td class="availability-type"></td>
+        <td><button class="danger small">Remove</button></td>
+      </tr>
+    </template>
+
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,495 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f6f8fb;
+  --panel: #ffffff;
+  --border: #d9e1ec;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --secondary: #0f172a;
+  --danger: #dc2626;
+  --text: #0f172a;
+  --muted: #64748b;
+  --success: #047857;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #eff6ff 0%, #f9fafb 60%, #f1f5f9 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+.app-header {
+  padding: 1.75rem 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.tagline {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-top: 0.4rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.timestamp {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 2rem 3rem 3rem;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.legend {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.badge.independent {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary);
+}
+
+.badge.training {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--danger);
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+}
+
+button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--secondary);
+}
+
+button.secondary:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+button.danger {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--danger);
+}
+
+button.danger:hover {
+  background: rgba(220, 38, 38, 0.2);
+}
+
+button.small {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+a.link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+a.link-button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--secondary);
+}
+
+a.link-button.secondary:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-actions button {
+  flex: none;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.pending-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.pending-section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.pending-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pending-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: white;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.04);
+}
+
+.pending-item-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pending-item-time {
+  margin: 0;
+  font-weight: 600;
+  color: var(--secondary);
+}
+
+.pending-item-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.pending-item-notes {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--secondary);
+  font-style: italic;
+}
+
+.pending-item button {
+  flex-shrink: 0;
+}
+
+input,
+ select,
+ textarea {
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  background: #f8fafc;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.availability-table {
+  max-height: 240px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.availability-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.availability-table th,
+.availability-table td {
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.9rem;
+}
+
+.availability-table tbody tr:nth-child(odd) {
+  background: rgba(241, 245, 249, 0.5);
+}
+
+#calendar {
+  background: #fff;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.fc-toolbar.fc-header-toolbar {
+  padding: 0.75rem 1rem;
+}
+
+.fc-toolbar-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.fc .fc-timegrid-slot-label {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.fc .training-event {
+  background: rgba(220, 38, 38, 0.12);
+  border: 1px solid rgba(220, 38, 38, 0.45);
+  color: var(--danger);
+}
+
+.fc .independent-event {
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  color: var(--primary);
+}
+
+.fc-event {
+  border-radius: 12px;
+  padding: 0.35rem;
+}
+
+.fc-event-main {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.fc .fc-daygrid-event {
+  border-radius: 8px;
+  padding: 0.3rem 0.5rem;
+}
+
+#openSlots {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+#openSlots li {
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  color: var(--primary);
+  display: flex;
+  justify-content: space-between;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.summary-table th,
+.summary-table td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.summary-table tbody tr:nth-child(even) {
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.availability-layout {
+  max-width: 720px;
+  margin: 2.5rem auto 4rem;
+  padding: 0 1.5rem;
+}
+
+.availability-layout .panel {
+  gap: 1rem;
+}
+
+.availability-intro {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.status-message {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--secondary);
+}
+
+.status-message.success {
+  background: rgba(4, 120, 87, 0.12);
+  color: var(--success);
+}
+
+.status-message.error {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--danger);
+}
+
+.availability-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.availability-table th,
+.availability-table td {
+  padding: 0.6rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.availability-table td.actions {
+  width: 80px;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-style: italic;
+  padding: 0.5rem 0;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+  .panel {
+    padding: 1.25rem;
+  }
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/server/data/store.json
+++ b/server/data/store.json
@@ -1,0 +1,1471 @@
+{
+  "interns": [
+    {
+      "id": "aforbes",
+      "name": "A. Forbes",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "sbabolal",
+      "name": "S. Babolal",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "mpowell",
+      "name": "M. Powell",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "nsmith",
+      "name": "N. Smith",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "sosalmon",
+      "name": "So. Salmon",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "tburnett",
+      "name": "T. Burnett",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "kbembridge",
+      "name": "K. Bembridge",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "cclarke",
+      "name": "C. Clarke",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "ttbrown",
+      "name": "TT. Brown",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "mwilliams",
+      "name": "M. Williams",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "jmcmahon",
+      "name": "J. McMahon",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "jmitchell",
+      "name": "J. Mitchell",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "acameron",
+      "name": "A. Cameron",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "bjones",
+      "name": "B. Jones",
+      "isTrainer": true,
+      "requiresTrainer": false
+    },
+    {
+      "id": "aroberts",
+      "name": "A. Roberts",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "lhassel",
+      "name": "L. Hassel",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "szbrown",
+      "name": "SZ. Brown",
+      "isTrainer": false,
+      "requiresTrainer": true
+    },
+    {
+      "id": "abrown",
+      "name": "A. Brown",
+      "isTrainer": false,
+      "requiresTrainer": true
+    },
+    {
+      "id": "sesalmon",
+      "name": "Se. Salmon",
+      "isTrainer": false,
+      "requiresTrainer": true
+    },
+    {
+      "id": "shoo",
+      "name": "S. Hoo",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "tsmith",
+      "name": "T. Smith",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "awilliamson",
+      "name": "A. Williamson",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "jgiscombe",
+      "name": "J. Giscombe",
+      "isTrainer": false,
+      "requiresTrainer": false
+    },
+    {
+      "id": "amurdock",
+      "name": "A. Murdock",
+      "isTrainer": false,
+      "requiresTrainer": false
+    }
+  ],
+  "availabilities": [
+    {
+      "id": "av-0001",
+      "internId": "aforbes",
+      "day": "Monday",
+      "start": "08:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0002",
+      "internId": "aforbes",
+      "day": "Monday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0003",
+      "internId": "aforbes",
+      "day": "Tuesday",
+      "start": "08:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0004",
+      "internId": "aforbes",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0005",
+      "internId": "aforbes",
+      "day": "Thursday",
+      "start": "08:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0006",
+      "internId": "aforbes",
+      "day": "Friday",
+      "start": "08:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0007",
+      "internId": "sbabolal",
+      "day": "Monday",
+      "start": "07:00",
+      "end": "11:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0008",
+      "internId": "sbabolal",
+      "day": "Tuesday",
+      "start": "10:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0009",
+      "internId": "sbabolal",
+      "day": "Wednesday",
+      "start": "10:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0010",
+      "internId": "sbabolal",
+      "day": "Thursday",
+      "start": "12:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0011",
+      "internId": "sbabolal",
+      "day": "Friday",
+      "start": "12:00",
+      "end": "14:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0012",
+      "internId": "mpowell",
+      "day": "Monday",
+      "start": "08:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0013",
+      "internId": "mpowell",
+      "day": "Monday",
+      "start": "17:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0014",
+      "internId": "mpowell",
+      "day": "Tuesday",
+      "start": "08:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0015",
+      "internId": "mpowell",
+      "day": "Wednesday",
+      "start": "14:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0016",
+      "internId": "mpowell",
+      "day": "Thursday",
+      "start": "07:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0017",
+      "internId": "mpowell",
+      "day": "Friday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0018",
+      "internId": "mpowell",
+      "day": "Friday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0019",
+      "internId": "nsmith",
+      "day": "Monday",
+      "start": "10:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0020",
+      "internId": "nsmith",
+      "day": "Tuesday",
+      "start": "10:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0021",
+      "internId": "nsmith",
+      "day": "Wednesday",
+      "start": "09:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0022",
+      "internId": "nsmith",
+      "day": "Thursday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0023",
+      "internId": "nsmith",
+      "day": "Friday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0024",
+      "internId": "sosalmon",
+      "day": "Monday",
+      "start": "09:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0025",
+      "internId": "sosalmon",
+      "day": "Tuesday",
+      "start": "07:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0026",
+      "internId": "sosalmon",
+      "day": "Wednesday",
+      "start": "10:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0027",
+      "internId": "sosalmon",
+      "day": "Thursday",
+      "start": "07:00",
+      "end": "10:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0028",
+      "internId": "sosalmon",
+      "day": "Thursday",
+      "start": "14:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0029",
+      "internId": "sosalmon",
+      "day": "Friday",
+      "start": "07:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0030",
+      "internId": "tburnett",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0031",
+      "internId": "tburnett",
+      "day": "Tuesday",
+      "start": "07:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0032",
+      "internId": "tburnett",
+      "day": "Wednesday",
+      "start": "07:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0033",
+      "internId": "tburnett",
+      "day": "Thursday",
+      "start": "07:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0034",
+      "internId": "tburnett",
+      "day": "Thursday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0035",
+      "internId": "tburnett",
+      "day": "Friday",
+      "start": "07:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0036",
+      "internId": "kbembridge",
+      "day": "Monday",
+      "start": "12:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0037",
+      "internId": "kbembridge",
+      "day": "Tuesday",
+      "start": "10:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0038",
+      "internId": "kbembridge",
+      "day": "Tuesday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0039",
+      "internId": "kbembridge",
+      "day": "Wednesday",
+      "start": "13:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0040",
+      "internId": "kbembridge",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0041",
+      "internId": "kbembridge",
+      "day": "Friday",
+      "start": "13:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0042",
+      "internId": "cclarke",
+      "day": "Monday",
+      "start": "12:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0043",
+      "internId": "cclarke",
+      "day": "Tuesday",
+      "start": "11:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0044",
+      "internId": "cclarke",
+      "day": "Wednesday",
+      "start": "07:00",
+      "end": "14:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0045",
+      "internId": "cclarke",
+      "day": "Thursday",
+      "start": "10:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0046",
+      "internId": "cclarke",
+      "day": "Friday",
+      "start": "10:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0047",
+      "internId": "ttbrown",
+      "day": "Monday",
+      "start": "07:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0048",
+      "internId": "ttbrown",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0049",
+      "internId": "ttbrown",
+      "day": "Wednesday",
+      "start": "07:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0050",
+      "internId": "ttbrown",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0051",
+      "internId": "ttbrown",
+      "day": "Friday",
+      "start": "12:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0052",
+      "internId": "mwilliams",
+      "day": "Monday",
+      "start": "12:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0053",
+      "internId": "mwilliams",
+      "day": "Tuesday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0054",
+      "internId": "mwilliams",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0055",
+      "internId": "mwilliams",
+      "day": "Wednesday",
+      "start": "12:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0056",
+      "internId": "mwilliams",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0057",
+      "internId": "mwilliams",
+      "day": "Thursday",
+      "start": "14:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0058",
+      "internId": "mwilliams",
+      "day": "Friday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0059",
+      "internId": "mwilliams",
+      "day": "Friday",
+      "start": "14:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0060",
+      "internId": "jmcmahon",
+      "day": "Monday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0061",
+      "internId": "jmcmahon",
+      "day": "Tuesday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0062",
+      "internId": "jmcmahon",
+      "day": "Wednesday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0063",
+      "internId": "jmcmahon",
+      "day": "Thursday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0064",
+      "internId": "jmcmahon",
+      "day": "Friday",
+      "start": "19:00",
+      "end": "22:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0065",
+      "internId": "jmitchell",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0066",
+      "internId": "jmitchell",
+      "day": "Tuesday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0067",
+      "internId": "jmitchell",
+      "day": "Wednesday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0068",
+      "internId": "jmitchell",
+      "day": "Thursday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0069",
+      "internId": "jmitchell",
+      "day": "Friday",
+      "start": "16:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0070",
+      "internId": "acameron",
+      "day": "Monday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0071",
+      "internId": "acameron",
+      "day": "Tuesday",
+      "start": "11:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0072",
+      "internId": "acameron",
+      "day": "Wednesday",
+      "start": "11:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0073",
+      "internId": "acameron",
+      "day": "Thursday",
+      "start": "12:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0074",
+      "internId": "acameron",
+      "day": "Friday",
+      "start": "12:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0075",
+      "internId": "bjones",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0076",
+      "internId": "bjones",
+      "day": "Tuesday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0077",
+      "internId": "bjones",
+      "day": "Wednesday",
+      "start": "16:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0078",
+      "internId": "bjones",
+      "day": "Thursday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0079",
+      "internId": "bjones",
+      "day": "Friday",
+      "start": "14:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0080",
+      "internId": "aroberts",
+      "day": "Monday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0081",
+      "internId": "aroberts",
+      "day": "Monday",
+      "start": "15:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0082",
+      "internId": "aroberts",
+      "day": "Tuesday",
+      "start": "14:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0083",
+      "internId": "aroberts",
+      "day": "Wednesday",
+      "start": "12:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0084",
+      "internId": "aroberts",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0085",
+      "internId": "aroberts",
+      "day": "Friday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0086",
+      "internId": "lhassel",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0087",
+      "internId": "lhassel",
+      "day": "Tuesday",
+      "start": "16:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0088",
+      "internId": "lhassel",
+      "day": "Wednesday",
+      "start": "17:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0089",
+      "internId": "lhassel",
+      "day": "Thursday",
+      "start": "14:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0090",
+      "internId": "lhassel",
+      "day": "Friday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0091",
+      "internId": "szbrown",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "tburnett",
+      "notes": ""
+    },
+    {
+      "id": "av-0092",
+      "internId": "szbrown",
+      "day": "Tuesday",
+      "start": "07:00",
+      "end": "10:00",
+      "sessionType": "training",
+      "trainerId": "tburnett",
+      "notes": ""
+    },
+    {
+      "id": "av-0093",
+      "internId": "szbrown",
+      "day": "Wednesday",
+      "start": "09:00",
+      "end": "14:00",
+      "sessionType": "training",
+      "trainerId": "tburnett",
+      "notes": ""
+    },
+    {
+      "id": "av-0094",
+      "internId": "szbrown",
+      "day": "Thursday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "tburnett",
+      "notes": ""
+    },
+    {
+      "id": "av-0095",
+      "internId": "szbrown",
+      "day": "Friday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "tburnett",
+      "notes": ""
+    },
+    {
+      "id": "av-0096",
+      "internId": "abrown",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "aforbes",
+      "notes": ""
+    },
+    {
+      "id": "av-0097",
+      "internId": "abrown",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "18:00",
+      "sessionType": "training",
+      "trainerId": "aforbes",
+      "notes": ""
+    },
+    {
+      "id": "av-0098",
+      "internId": "abrown",
+      "day": "Wednesday",
+      "start": "09:00",
+      "end": "11:00",
+      "sessionType": "training",
+      "trainerId": "aforbes",
+      "notes": ""
+    },
+    {
+      "id": "av-0099",
+      "internId": "abrown",
+      "day": "Thursday",
+      "start": "13:00",
+      "end": "18:00",
+      "sessionType": "training",
+      "trainerId": "aforbes",
+      "notes": ""
+    },
+    {
+      "id": "av-0100",
+      "internId": "abrown",
+      "day": "Friday",
+      "start": "12:00",
+      "end": "15:00",
+      "sessionType": "training",
+      "trainerId": "aforbes",
+      "notes": ""
+    },
+    {
+      "id": "av-0101",
+      "internId": "sesalmon",
+      "day": "Monday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "training",
+      "trainerId": "cclarke",
+      "notes": ""
+    },
+    {
+      "id": "av-0102",
+      "internId": "sesalmon",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "17:00",
+      "sessionType": "training",
+      "trainerId": "cclarke",
+      "notes": ""
+    },
+    {
+      "id": "av-0103",
+      "internId": "sesalmon",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "14:00",
+      "sessionType": "training",
+      "trainerId": "cclarke",
+      "notes": ""
+    },
+    {
+      "id": "av-0104",
+      "internId": "sesalmon",
+      "day": "Thursday",
+      "start": "16:00",
+      "end": "18:00",
+      "sessionType": "training",
+      "trainerId": "cclarke",
+      "notes": ""
+    },
+    {
+      "id": "av-0105",
+      "internId": "sesalmon",
+      "day": "Friday",
+      "start": "10:00",
+      "end": "14:00",
+      "sessionType": "training",
+      "trainerId": "cclarke",
+      "notes": ""
+    },
+    {
+      "id": "av-0106",
+      "internId": "shoo",
+      "day": "Monday",
+      "start": "12:00",
+      "end": "15:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0107",
+      "internId": "shoo",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0108",
+      "internId": "shoo",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "11:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0109",
+      "internId": "shoo",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0110",
+      "internId": "shoo",
+      "day": "Friday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0111",
+      "internId": "tsmith",
+      "day": "Monday",
+      "start": "13:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0112",
+      "internId": "tsmith",
+      "day": "Tuesday",
+      "start": "09:00",
+      "end": "14:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0113",
+      "internId": "tsmith",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "13:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0114",
+      "internId": "tsmith",
+      "day": "Thursday",
+      "start": "11:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0115",
+      "internId": "tsmith",
+      "day": "Friday",
+      "start": "10:00",
+      "end": "14:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0116",
+      "internId": "awilliamson",
+      "day": "Monday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0117",
+      "internId": "awilliamson",
+      "day": "Tuesday",
+      "start": "13:00",
+      "end": "18:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0118",
+      "internId": "awilliamson",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "10:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0119",
+      "internId": "awilliamson",
+      "day": "Thursday",
+      "start": "16:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0120",
+      "internId": "awilliamson",
+      "day": "Friday",
+      "start": "16:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0121",
+      "internId": "jgiscombe",
+      "day": "Monday",
+      "start": "12:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0122",
+      "internId": "jgiscombe",
+      "day": "Tuesday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0123",
+      "internId": "jgiscombe",
+      "day": "Wednesday",
+      "start": "14:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0124",
+      "internId": "jgiscombe",
+      "day": "Thursday",
+      "start": "11:00",
+      "end": "16:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0125",
+      "internId": "jgiscombe",
+      "day": "Friday",
+      "start": "15:00",
+      "end": "19:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0126",
+      "internId": "amurdock",
+      "day": "Monday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0127",
+      "internId": "amurdock",
+      "day": "Monday",
+      "start": "14:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0128",
+      "internId": "amurdock",
+      "day": "Tuesday",
+      "start": "08:00",
+      "end": "10:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0129",
+      "internId": "amurdock",
+      "day": "Wednesday",
+      "start": "08:00",
+      "end": "10:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0130",
+      "internId": "amurdock",
+      "day": "Thursday",
+      "start": "09:00",
+      "end": "17:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    },
+    {
+      "id": "av-0131",
+      "internId": "amurdock",
+      "day": "Friday",
+      "start": "09:00",
+      "end": "12:00",
+      "sessionType": "independent",
+      "trainerId": null,
+      "notes": ""
+    }
+  ],
+  "schedule": {
+    "assignments": [],
+    "generatedAt": null,
+    "openSlots": [],
+    "totalsByIntern": []
+  },
+  "settings": {
+    "maxStations": 9,
+    "dayStart": "07:00",
+    "dayEnd": "22:00"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,656 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, 'data');
+const DATA_PATH = path.join(DATA_DIR, 'store.json');
+const CLIENT_DIR = path.join(__dirname, '..', 'public');
+const PORT = process.env.PORT || 3000;
+
+const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+function ensureStore() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+
+  if (fs.existsSync(DATA_PATH)) {
+    return;
+  }
+
+  const initial = {
+    interns: [],
+    availabilities: [],
+    schedule: { assignments: [], generatedAt: null, openSlots: [] },
+    settings: { maxStations: 9, dayStart: '07:00', dayEnd: '22:00' }
+  };
+  fs.writeFileSync(DATA_PATH, JSON.stringify(initial, null, 2));
+}
+
+function readStore() {
+  ensureStore();
+  const raw = fs.readFileSync(DATA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeStore(data) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!body) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function sendJSON(res, statusCode, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(payload);
+}
+
+function sendText(res, statusCode, text) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'text/plain',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(text);
+}
+
+function getMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html';
+    case '.css':
+      return 'text/css';
+    case '.js':
+      return 'application/javascript';
+    case '.json':
+      return 'application/json';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function timeToNumber(timeStr) {
+  const [hour, minute] = timeStr.split(':').map(Number);
+  return hour + minute / 60;
+}
+
+function formatHourLabel(hour) {
+  const end = hour + 1;
+  const toLabel = (value) => {
+    const period = value >= 12 ? 'P.M.' : 'A.M.';
+    const normalized = value % 12 === 0 ? 12 : value % 12;
+    return `${normalized}:00 ${period}`;
+  };
+  return `${toLabel(hour)} – ${toLabel(end)}`;
+}
+
+function pad(num) {
+  return num.toString().padStart(2, '0');
+}
+
+function numberToTime(num) {
+  const hour = Math.floor(num);
+  const minute = Math.round((num - hour) * 60);
+  return `${pad(hour)}:${pad(minute)}`;
+}
+
+function getHourSlots(day, start, end) {
+  const slots = [];
+  let cursor = timeToNumber(start);
+  const endNum = timeToNumber(end);
+  while (cursor < endNum) {
+    slots.push({ day, hour: cursor });
+    cursor += 1;
+  }
+  return slots;
+}
+
+function generateId(prefix = 'id') {
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function buildSchedule(data) {
+  const { interns, availabilities, settings } = data;
+  const maxStations = settings?.maxStations || 9;
+  const internMap = Object.fromEntries(interns.map((intern) => [intern.id, intern]));
+
+  const assignedHours = {};
+  const assignedHoursByDay = {};
+  const requestedHours = {};
+  interns.forEach((intern) => {
+    assignedHours[intern.id] = 0;
+    assignedHoursByDay[intern.id] = {};
+    requestedHours[intern.id] = 0;
+  });
+
+  const slotCandidates = new Map();
+  availabilities.forEach((availability) => {
+    const { internId, day, start, end } = availability;
+    const intern = internMap[internId];
+    if (!intern) return;
+    const slots = getHourSlots(day, start, end);
+    requestedHours[internId] = (requestedHours[internId] || 0) + slots.length;
+    slots.forEach(({ day: slotDay, hour }) => {
+      const key = `${slotDay}-${hour}`;
+      if (!slotCandidates.has(key)) {
+        slotCandidates.set(key, []);
+      }
+      slotCandidates.get(key).push({
+        availability,
+        intern,
+        hour
+      });
+    });
+  });
+
+  const assignments = [];
+  const openSlots = [];
+  const waitlistedBySlot = {};
+
+  const scheduledParticipants = new Map();
+
+  function sortCandidates(candidates, day) {
+    return candidates.sort((a, b) => {
+      const aAssigned = assignedHours[a.intern.id] || 0;
+      const bAssigned = assignedHours[b.intern.id] || 0;
+      const aRequested = requestedHours[a.intern.id] || 1;
+      const bRequested = requestedHours[b.intern.id] || 1;
+      const aDayHours = assignedHoursByDay[a.intern.id]?.[day] || 0;
+      const bDayHours = assignedHoursByDay[b.intern.id]?.[day] || 0;
+      if (aDayHours !== bDayHours) {
+        return aDayHours - bDayHours;
+      }
+      const aRatio = aAssigned / aRequested;
+      const bRatio = bAssigned / bRequested;
+      if (aRatio !== bRatio) {
+        return aRatio - bRatio;
+      }
+      if (aAssigned !== bAssigned) {
+        return aAssigned - bAssigned;
+      }
+      return a.intern.name.localeCompare(b.intern.name);
+    });
+  }
+
+  function canPlaceParticipant(participantId, key) {
+    if (!participantId) return true;
+    const scheduled = scheduledParticipants.get(key);
+    if (!scheduled) return true;
+    return !scheduled.has(participantId);
+  }
+
+  function markParticipants(participants, key) {
+    if (!scheduledParticipants.has(key)) {
+      scheduledParticipants.set(key, new Set());
+    }
+    const store = scheduledParticipants.get(key);
+    participants.forEach((id) => id && store.add(id));
+  }
+
+  const orderedKeys = Array.from(slotCandidates.keys()).sort((a, b) => {
+    const [dayA, hourA] = a.split('-');
+    const [dayB, hourB] = b.split('-');
+    const dayComparison = DAY_ORDER.indexOf(dayA) - DAY_ORDER.indexOf(dayB);
+    if (dayComparison !== 0) return dayComparison;
+    return Number(hourA) - Number(hourB);
+  });
+
+  orderedKeys.forEach((key) => {
+    const [day, hour] = key.split('-');
+    const numericHour = Number(hour);
+    const candidates = slotCandidates.get(key) || [];
+    const trainingCandidates = candidates.filter((item) => item.availability.sessionType === 'training');
+    const independentCandidates = candidates.filter((item) => item.availability.sessionType !== 'training');
+
+    const sortedTraining = sortCandidates([...trainingCandidates], day);
+
+    const slotAssignments = [];
+
+    // Process training sessions first to guarantee trainer pairing.
+    sortedTraining.forEach((candidate) => {
+      const { availability, intern } = candidate;
+      const trainer = internMap[availability.trainerId];
+      if (!trainer) {
+        return;
+      }
+      const trainerAvailability = availabilities.find((entry) => entry.internId === trainer.id && entry.day === day && timeToNumber(entry.start) <= numericHour && timeToNumber(entry.end) > numericHour);
+      if (!trainerAvailability) {
+        return;
+      }
+      if (!canPlaceParticipant(intern.id, key) || !canPlaceParticipant(trainer.id, key)) {
+        return;
+      }
+      slotAssignments.push({
+        id: generateId('assign'),
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        station: slotAssignments.length + 1,
+        internId: intern.id,
+        trainerId: trainer.id,
+        type: 'training',
+        source: 'auto'
+      });
+      assignedHours[intern.id] = (assignedHours[intern.id] || 0) + 1;
+      assignedHours[trainer.id] = (assignedHours[trainer.id] || 0) + 1;
+      assignedHoursByDay[intern.id][day] = (assignedHoursByDay[intern.id][day] || 0) + 1;
+      assignedHoursByDay[trainer.id][day] = (assignedHoursByDay[trainer.id][day] || 0) + 1;
+      markParticipants([intern.id, trainer.id], key);
+    });
+
+    const sortedIndependent = sortCandidates(independentCandidates, day);
+
+    const waitlisted = [];
+    sortedIndependent.forEach((candidate, index) => {
+      if (slotAssignments.length >= maxStations) {
+        waitlisted.push(candidate.intern.id);
+        return;
+      }
+      const { intern } = candidate;
+      if (!canPlaceParticipant(intern.id, key)) {
+        waitlisted.push(intern.id);
+        return;
+      }
+      slotAssignments.push({
+        id: generateId('assign'),
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        station: slotAssignments.length + 1,
+        internId: intern.id,
+        trainerId: null,
+        type: 'independent',
+        source: 'auto'
+      });
+      assignedHours[intern.id] = (assignedHours[intern.id] || 0) + 1;
+      assignedHoursByDay[intern.id][day] = (assignedHoursByDay[intern.id][day] || 0) + 1;
+      markParticipants([intern.id], key);
+    });
+
+    if (waitlisted.length) {
+      waitlistedBySlot[key] = waitlisted;
+    }
+
+    slotAssignments.forEach((assignment) => {
+      assignments.push(assignment);
+    });
+
+    const open = Math.max(maxStations - slotAssignments.length, 0);
+    if (open > 0) {
+      openSlots.push({
+        day,
+        hour: numericHour,
+        start: numberToTime(numericHour),
+        end: numberToTime(numericHour + 1),
+        availableStations: open
+      });
+    }
+  });
+
+  const totalsByIntern = interns.map((intern) => ({
+    internId: intern.id,
+    name: intern.name,
+    requestedHours: requestedHours[intern.id] || 0,
+    assignedHours: assignedHours[intern.id] || 0
+  }));
+
+  const daySummaries = {};
+  assignments.forEach((assignment) => {
+    if (!daySummaries[assignment.day]) {
+      daySummaries[assignment.day] = { assignments: 0, trainings: 0 };
+    }
+    daySummaries[assignment.day].assignments += 1;
+    if (assignment.type === 'training') {
+      daySummaries[assignment.day].trainings += 1;
+    }
+  });
+
+  return {
+    assignments,
+    openSlots,
+    totalsByIntern,
+    waitlistedBySlot,
+    daySummaries
+  };
+}
+
+function getAssignmentsByHour(assignments, day, start, end, ignoreId) {
+  const startNum = timeToNumber(start);
+  const endNum = timeToNumber(end);
+  return assignments.filter((assignment) => {
+    if (assignment.id === ignoreId) return false;
+    if (assignment.day !== day) return false;
+    const assignmentStart = timeToNumber(assignment.start);
+    const assignmentEnd = timeToNumber(assignment.end);
+    return assignmentStart < endNum && assignmentEnd > startNum;
+  });
+}
+
+function validateAssignmentPlacement(data, candidate, ignoreId = null) {
+  const { schedule, settings } = data;
+  const maxStations = settings?.maxStations || 9;
+  const assignments = schedule.assignments || [];
+  const participants = new Set([candidate.internId, candidate.trainerId].filter(Boolean));
+  const overlapping = getAssignmentsByHour(assignments, candidate.day, candidate.start, candidate.end, ignoreId);
+
+  for (const assignment of overlapping) {
+    const otherParticipants = new Set([assignment.internId, assignment.trainerId].filter(Boolean));
+    for (const participant of participants) {
+      if (otherParticipants.has(participant)) {
+        return { ok: false, reason: 'Participant is already assigned during this time block.' };
+      }
+    }
+  }
+
+  const hourSlots = getHourSlots(candidate.day, candidate.start, candidate.end);
+  for (const slot of hourSlots) {
+    const keyAssignments = overlapping.filter((assignment) => timeToNumber(assignment.start) <= slot.hour && timeToNumber(assignment.end) > slot.hour);
+    const stationCount = keyAssignments.length;
+    if (stationCount >= maxStations) {
+      return { ok: false, reason: 'All stations are occupied during at least one hour in this range.' };
+    }
+  }
+  return { ok: true };
+}
+
+async function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return;
+  }
+
+  try {
+    if (pathname === '/api/settings' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.settings || {});
+    }
+
+    if (pathname === '/api/interns' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.interns || []);
+    }
+
+    if (pathname === '/api/interns' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      if (!payload.name) {
+        return sendJSON(res, 400, { error: 'Name is required.' });
+      }
+      const data = readStore();
+      const intern = {
+        id: generateId('intern'),
+        name: payload.name,
+        isTrainer: Boolean(payload.isTrainer),
+        requiresTrainer: Boolean(payload.requiresTrainer)
+      };
+      data.interns.push(intern);
+      writeStore(data);
+      return sendJSON(res, 201, intern);
+    }
+
+    if (pathname === '/api/availabilities' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.availabilities || []);
+    }
+
+    if (pathname === '/api/availabilities' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      const data = readStore();
+
+      let entries = Array.isArray(payload.entries) ? payload.entries : [];
+      if (entries.length === 0) {
+        entries = [
+          {
+            internId: payload.internId,
+            day: payload.day,
+            start: payload.start,
+            end: payload.end,
+            sessionType: payload.sessionType,
+            trainerId: payload.trainerId,
+            notes: payload.notes
+          }
+        ];
+      }
+
+      if (!entries.length) {
+        return sendJSON(res, 400, { error: 'At least one availability window is required.' });
+      }
+
+      const created = [];
+
+      for (let index = 0; index < entries.length; index += 1) {
+        const entry = entries[index] || {};
+        const internId = entry.internId || payload.internId;
+        if (!internId) {
+          return sendJSON(res, 400, { error: `Entry ${index + 1}: Intern is required.` });
+        }
+        const intern = data.interns.find((item) => item.id === internId);
+        if (!intern) {
+          return sendJSON(res, 404, { error: `Entry ${index + 1}: Intern not found.` });
+        }
+
+        const day = entry.day || payload.day;
+        const start = entry.start || payload.start;
+        const end = entry.end || payload.end;
+        if (!day || !start || !end) {
+          return sendJSON(res, 400, { error: `Entry ${index + 1}: Day, start and end are required.` });
+        }
+
+        const startNum = timeToNumber(start);
+        const endNum = timeToNumber(end);
+        if (Number.isNaN(startNum) || Number.isNaN(endNum) || endNum <= startNum) {
+          return sendJSON(res, 400, { error: `Entry ${index + 1}: End time must be later than start time.` });
+        }
+
+        const sessionTypeValue = entry.sessionType || payload.sessionType;
+        const sessionType = sessionTypeValue === 'training' ? 'training' : 'independent';
+        const trainerId = sessionType === 'training' ? entry.trainerId || payload.trainerId : null;
+        if (sessionType === 'training' && !trainerId) {
+          return sendJSON(res, 400, { error: `Entry ${index + 1}: Training sessions require a trainer.` });
+        }
+
+        const rawNotes = entry.notes !== undefined ? entry.notes : payload.notes;
+        const notes = typeof rawNotes === 'string' ? rawNotes.trim() : '';
+
+        created.push({
+          id: generateId('availability'),
+          internId,
+          day,
+          start,
+          end,
+          sessionType,
+          trainerId: sessionType === 'training' ? trainerId : null,
+          notes
+        });
+      }
+
+      data.availabilities.push(...created);
+      writeStore(data);
+
+      if (created.length === 1 && !Array.isArray(payload.entries)) {
+        return sendJSON(res, 201, created[0]);
+      }
+
+      return sendJSON(res, 201, { created });
+    }
+
+    if (pathname.startsWith('/api/availabilities/') && req.method === 'DELETE') {
+      const id = pathname.split('/').pop();
+      const data = readStore();
+      const before = data.availabilities.length;
+      data.availabilities = data.availabilities.filter((item) => item.id !== id);
+      if (data.availabilities.length === before) {
+        return sendJSON(res, 404, { error: 'Availability not found.' });
+      }
+      writeStore(data);
+      return sendJSON(res, 200, { success: true });
+    }
+
+    if (pathname === '/api/schedule' && req.method === 'GET') {
+      const data = readStore();
+      return sendJSON(res, 200, data.schedule || { assignments: [], openSlots: [] });
+    }
+
+    if (pathname === '/api/schedule/generate' && req.method === 'POST') {
+      const data = readStore();
+      const result = buildSchedule(data);
+      data.schedule = {
+        assignments: result.assignments,
+        openSlots: result.openSlots,
+        totalsByIntern: result.totalsByIntern,
+        waitlistedBySlot: result.waitlistedBySlot,
+        daySummaries: result.daySummaries,
+        generatedAt: new Date().toISOString()
+      };
+      writeStore(data);
+      return sendJSON(res, 200, data.schedule);
+    }
+
+    if (pathname.startsWith('/api/schedule/assignment/') && req.method === 'PUT') {
+      const id = pathname.split('/').pop();
+      const payload = await parseBody(req);
+      const data = readStore();
+      const assignment = data.schedule.assignments.find((item) => item.id === id);
+      if (!assignment) {
+        return sendJSON(res, 404, { error: 'Assignment not found.' });
+      }
+      const candidate = {
+        ...assignment,
+        day: payload.day || assignment.day,
+        start: payload.start || assignment.start,
+        end: payload.end || assignment.end,
+        station: payload.station || assignment.station
+      };
+      const validation = validateAssignmentPlacement(data, candidate, id);
+      if (!validation.ok) {
+        return sendJSON(res, 400, { error: validation.reason });
+      }
+      Object.assign(assignment, candidate, { source: 'manual' });
+      writeStore(data);
+      return sendJSON(res, 200, assignment);
+    }
+
+    if (pathname === '/api/schedule/assignment' && req.method === 'POST') {
+      const payload = await parseBody(req);
+      const data = readStore();
+      if (!payload.internId || !payload.day || !payload.start || !payload.end) {
+        return sendJSON(res, 400, { error: 'Intern, day, start and end are required.' });
+      }
+      const assignment = {
+        id: generateId('assign'),
+        internId: payload.internId,
+        trainerId: payload.trainerId || null,
+        type: payload.trainerId ? 'training' : 'independent',
+        day: payload.day,
+        start: payload.start,
+        end: payload.end,
+        station: payload.station || (data.schedule.assignments.length % (data.settings?.maxStations || 9)) + 1,
+        source: 'manual'
+      };
+      const validation = validateAssignmentPlacement(data, assignment, null);
+      if (!validation.ok) {
+        return sendJSON(res, 400, { error: validation.reason });
+      }
+      data.schedule.assignments.push(assignment);
+      writeStore(data);
+      return sendJSON(res, 201, assignment);
+    }
+
+    if (pathname.startsWith('/api/schedule/assignment/') && req.method === 'DELETE') {
+      const id = pathname.split('/').pop();
+      const data = readStore();
+      const before = data.schedule.assignments.length;
+      data.schedule.assignments = data.schedule.assignments.filter((item) => item.id !== id);
+      if (data.schedule.assignments.length === before) {
+        return sendJSON(res, 404, { error: 'Assignment not found.' });
+      }
+      writeStore(data);
+      return sendJSON(res, 200, { success: true });
+    }
+
+    // Static assets
+    let filePath = path.join(CLIENT_DIR, pathname === '/' ? 'index.html' : pathname);
+    if (!filePath.startsWith(CLIENT_DIR)) {
+      return sendText(res, 403, 'Forbidden');
+    }
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        sendText(res, 404, 'Not Found');
+        return;
+      }
+      res.writeHead(200, {
+        'Content-Type': getMimeType(filePath),
+        'Access-Control-Allow-Origin': '*'
+      });
+      res.end(content);
+    });
+  } catch (error) {
+    console.error('Server error', error);
+    sendJSON(res, 500, { error: 'Internal server error', details: error.message });
+  }
+}
+
+function createServer() {
+  return http.createServer((req, res) => {
+    handleRequest(req, res).catch((error) => {
+      console.error('Unhandled server error', error);
+      if (!res.headersSent) {
+        sendJSON(res, 500, { error: 'Internal server error', details: error.message });
+      } else {
+        res.end();
+      }
+    });
+  });
+}
+
+if (require.main === module) {
+  const server = createServer();
+  server.listen(PORT, () => {
+    console.log(`Advance Scheduler API running on http://localhost:${PORT}`);
+  });
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- extend the scheduler to balance assignments per day and refresh the seeded availability roster to cover the full week
- surface a daily coverage table and weekday-focused calendar headers so admins can verify distribution at a glance
- document the day-level fairness logic and bundled weekly demo data in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7087c75208329a0e9f0bdd17b78bc